### PR TITLE
issue/#5 Update Gradle test filtering

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,29 +51,33 @@ tasks.named('test') {
 }
 
 tasks.register('unitTest', Test) {
-    description = 'Runs only unit tests.'
+	description = 'Runs only unit tests.'
     group = 'verification'
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
-    useJUnitPlatform {
-        includeTags 'unitTest'
-    }
+	useJUnitPlatform()
+
+	filter {
+		includeTestsMatching "backend.unit.*"
+	}
 }
 
 tasks.register('integrationTest', Test) {
-    description = 'Runs only integration tests.'
-    group = 'verification'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
+	description = 'Runs only integration tests.'
+	group = 'verification'
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
 
-    useJUnitPlatform {
-        includeTags 'integrationTest'
-    }
+	useJUnitPlatform()
+
+	filter {
+		includeTestsMatching "backend.integration.*"
+	}
 }
 
 spotless {
-    java {
+	java {
         googleJavaFormat('1.28.0')
         target 'src/**/*.java'
         endWithNewline()

--- a/backend/src/test/java/backend/integration/PlaceholderIntegrationTest.java
+++ b/backend/src/test/java/backend/integration/PlaceholderIntegrationTest.java
@@ -2,12 +2,10 @@ package backend.integration;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@Tag("integrationTest")
 public class PlaceholderIntegrationTest {
 
   // A placeholder test to check that custom Gradle task runs

--- a/backend/src/test/java/backend/unit/PlaceholderUnitTest.java
+++ b/backend/src/test/java/backend/unit/PlaceholderUnitTest.java
@@ -2,10 +2,8 @@ package backend.unit;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("unitTest")
 public class PlaceholderUnitTest {
 
   // A placeholder test to check that custom Gradle task runs


### PR DESCRIPTION
Closes #5 
This pull request updates the way unit and integration tests are selected and run in the Gradle build for the backend. Instead of using JUnit tags to filter tests, it now uses test class name patterns, simplifying test management and reducing the need for annotations in test classes.

**Build configuration changes:**

* Updated the `unitTest` and `integrationTest` Gradle tasks in `backend/build.gradle` to use the `filter` block with `includeTestsMatching` for selecting tests by class name pattern instead of JUnit tags. (`backend/build.gradle`, [[1]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddL59-R62) [[2]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddL70-R75)

**Test code cleanup:**

* Removed the `@Tag` annotation from `PlaceholderUnitTest` and `PlaceholderIntegrationTest` since test selection is now handled by class name patterns, making the test classes cleaner. (`backend/src/test/java/backend/unit/PlaceholderUnitTest.java`, [[1]](diffhunk://#diff-2f9cd82e75a97cee647e2641f4c75c2a36003a714ee8e242f8a9cda70c229d76L5-L8); `backend/src/test/java/backend/integration/PlaceholderIntegrationTest.java`, [[2]](diffhunk://#diff-45698b663452842b4f48a068a1814193842e3fe31e015b9c14fb9f8fd9b919b2L5-L10)