### PR TITLE
Chore/Remove redundant test task configuration

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,8 +51,8 @@ tasks.named('test') {
 }
 
 tasks.register('unitTest', Test) {
+	group = 'verification'
 	description = 'Runs only unit tests.'
-    group = 'verification'
 
 	useJUnitPlatform()
 
@@ -62,8 +62,8 @@ tasks.register('unitTest', Test) {
 }
 
 tasks.register('integrationTest', Test) {
-	description = 'Runs only integration tests.'
 	group = 'verification'
+	description = 'Runs only integration tests.'
 
 	useJUnitPlatform()
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,8 +53,6 @@ tasks.named('test') {
 tasks.register('unitTest', Test) {
 	description = 'Runs only unit tests.'
     group = 'verification'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
 
 	useJUnitPlatform()
 
@@ -66,8 +64,6 @@ tasks.register('unitTest', Test) {
 tasks.register('integrationTest', Test) {
 	description = 'Runs only integration tests.'
 	group = 'verification'
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath
 
 	useJUnitPlatform()
 


### PR DESCRIPTION
This pull request makes a minor update to the `backend/build.gradle` file by reordering the `description` field to appear after the `group` field in the `unitTest` and `integrationTest` task definitions. It also removes the `testClassesDirs` and `classpath` from task configuration as they are inherited from the `Test` task type.