### PR TITLE
issue/#4 Create reusable GitHub Actions workflows

### DIFF
--- a/.github/actions/setup-backend-workflow-environment/action.yaml
+++ b/.github/actions/setup-backend-workflow-environment/action.yaml
@@ -1,5 +1,5 @@
 name: Set up backend workflow environment
-description: Sets up Java version 25 and grants Gradle executive permissions for the workflow
+description: Sets up Java version 25 and grants Gradle execute permissions for the workflow
 
 runs:
   using: "composite"

--- a/.github/actions/setup-backend-workflow-environment/action.yaml
+++ b/.github/actions/setup-backend-workflow-environment/action.yaml
@@ -1,0 +1,16 @@
+name: Set up backend workflow environment
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: "25"
+        distribution: "temurin"
+
+    - name: Grant Gradle execute permissions
+      shell: bash
+      run: |
+        cd backend
+        chmod +x ./gradlew

--- a/.github/actions/setup-backend-workflow-environment/action.yaml
+++ b/.github/actions/setup-backend-workflow-environment/action.yaml
@@ -1,4 +1,5 @@
 name: Set up backend workflow environment
+description: Sets up Java version 25 and grants Gradle executive permissions for the workflow
 
 runs:
   using: "composite"

--- a/.github/actions/setup-frontend-workflow-environment/action.yaml
+++ b/.github/actions/setup-frontend-workflow-environment/action.yaml
@@ -3,9 +3,6 @@ name: Set up frontend workflow environment
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/setup-frontend-workflow-environment/action.yaml
+++ b/.github/actions/setup-frontend-workflow-environment/action.yaml
@@ -1,0 +1,18 @@
+name: Set up frontend workflow environment
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+    
+    - name: Install dependencies
+      shell: bash
+      run: |
+        cd frontend
+        npm install

--- a/.github/actions/setup-frontend-workflow-environment/action.yaml
+++ b/.github/actions/setup-frontend-workflow-environment/action.yaml
@@ -1,4 +1,5 @@
 name: Set up frontend workflow environment
+description: Sets up Node.js and dependencies for the workflow
 
 runs:
   using: "composite"
@@ -7,7 +8,7 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: "24"
-    
+
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -13,16 +13,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: "25"
-          distribution: "temurin"
-
-      - name: Grant Gradle execute permissions
-        run: |
-          cd backend
-          chmod +x ./gradlew
+      - name: Set up backend workflow environment
+        uses: ./.github/actions/setup-backend-workflow-environment
 
       - name: Run BE formatting check
         run: |
@@ -37,15 +29,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      
-      - name: Install dependencies
-        run: |
-          cd frontend
-          npm install
+      - name: Set up frontend workflow environment
+        uses: ./.github/actions/setup-frontend-workflow-environment
 
       - name: Run FE formatting check
         run: |
@@ -60,15 +45,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      
-      - name: Install dependencies
-        run: |
-          cd frontend
-          npm install
+      - name: Set up frontend workflow environment
+        uses: ./.github/actions/setup-frontend-workflow-environment
 
       - name: Run FE linting check
         run: |
@@ -83,16 +61,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: "25"
-          distribution: "temurin"
-
-      - name: Grant Gradle execute permissions
-        run: |
-          cd backend
-          chmod +x ./gradlew
+      - name: Set up backend workflow environment
+        uses: ./.github/actions/setup-backend-workflow-environment
       
       - name: Run BE unit tests
         run: |
@@ -107,16 +77,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: "25"
-          distribution: "temurin"
-
-      - name: Grant Gradle execute permissions
-        run: |
-          cd backend
-          chmod +x ./gradlew
+      - name: Set up backend workflow environment
+        uses: ./.github/actions/setup-backend-workflow-environment
       
       - name: Run BE integration tests
         run: |


### PR DESCRIPTION
Closes #4 
This pull request introduces a new composite GitHub Action to standardize and simplify the setup process for frontend workflows. The action checks out the code, sets up Node.js version 24, and installs frontend dependencies.

Workflow environment setup:

* Added a new composite action `.github/actions/setup-frontend-workflow-environment/action.yaml` that checks out the repository, sets up Node.js 24, and installs `npm` dependencies in the `frontend` directory.