### PR TITLE
Issue/#3 Add a script to run all formatters

### DIFF
--- a/run_formatters.sh
+++ b/run_formatters.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Run backend formatter
+format_backend() {
+    (cd backend && ./gradlew spotlessApply)
+}
+
+# Run frontend formatter and eslint
+format_frontend() {
+    (cd frontend && npx prettier . --write && npx eslint . --fix)
+}
+
+# Run formatters and linter
+format_backend && echo && format_frontend

--- a/run_formatters.sh
+++ b/run_formatters.sh
@@ -3,6 +3,10 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+# Check if correct directories exists
+if [[ ! -d "backend" ]]; then echo "ERROR: backend directory not found"; exit 1; fi
+if [[ ! -d "frontend" ]]; then echo "ERROR: frontend directory not found"; exit 1; fi
+
 # Run backend formatter
 format_backend() {
     (cd backend && ./gradlew spotlessApply)


### PR DESCRIPTION
This pull request introduces a new script, `run_formatters.sh`, that automates code formatting and linting for both the backend and frontend. The script ensures consistent code style across the project by running the appropriate tools for each part of the codebase.

Automation of code formatting and linting:

* Added `run_formatters.sh` script to run backend formatting using `spotlessApply` and frontend formatting and linting using `prettier` and `eslint` with automatic fixing.