### PR TITLE
Chore/Fix Gradle build file warning

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -77,6 +77,6 @@ spotless {
         googleJavaFormat('1.28.0')
         target 'src/**/*.java'
         endWithNewline()
-        lineEndings 'UNIX'
+        lineEndings = 'UNIX'
     }
 }


### PR DESCRIPTION
This pull request makes a small update to the `spotless` configuration in `backend/build.gradle`, changing the syntax for setting the `lineEndings` property to use assignment instead of a method call.