### PR TITLE
Issue/#7 Add a pre-commit hook for formatters

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,8 +21,6 @@ fi
 
 # Format frontend files (if exist)
 if [[ -n "$STAGED_FRONTEND_FILES" ]]; then
-    echo "Running frontend file formatting..."
-
     # Format all staged frontend files
     npx prettier --write $STAGED_FRONTEND_FILES
     if [[ $? -ne 0 ]]; then
@@ -31,7 +29,7 @@ if [[ -n "$STAGED_FRONTEND_FILES" ]]; then
     fi
 
     # Lint all staged frontend files
-    npx eslint --fix $STAGED_FRONTEND_FILES
+    npx eslint --fix $STAGED_FRONTEND_FILES -c "frontend/eslint.config.js"
     if [[ $? -ne 0 ]]; then
         echo "Frontend linting failed"
         exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Get all staged files
+STAGED_BACKEND_FILES=$(git diff --cached --name-only | grep "^backend/.*\.java$" || true)
+STAGED_FRONTEND_FILES=$(git diff --cached --name-only | grep "^frontend/" || true)
+
+# Format backend files (if exist)
+if [[ -n "$STAGED_BACKEND_FILES" ]]; then
+    # Format backend files
+    (cd backend && ./gradlew spotlessApply)
+
+    # Exit early if formatting fails
+    if [[ $? -ne 0 ]]; then
+        echo "Backend formatting failed"
+        exit 1
+    fi
+
+    # Re-stage formatted files
+    git add $STAGED_BACKEND_FILES
+fi
+
+# Format frontend files (if exist)
+if [[ -n "$STAGED_FRONTEND_FILES" ]]; then
+    echo "Running frontend file formatting..."
+
+    # Format all staged frontend files
+    npx prettier --write $STAGED_FRONTEND_FILES
+    if [[ $? -ne 0 ]]; then
+        echo "Frontend formatting failed"
+        exit 1
+    fi
+
+    # Lint all staged frontend files
+    npx eslint --fix $STAGED_FRONTEND_FILES
+    if [[ $? -ne 0 ]]; then
+        echo "Frontend linting failed"
+        exit 1
+    fi
+
+    # Re-stage formatted files
+    git add $STAGED_FRONTEND_FILES
+fi
+
+exit 0


### PR DESCRIPTION
Closes #7
This pull request introduces a new pre-commit hook script to automate code formatting and linting for both backend and frontend files before commits. The script ensures code quality by running formatting and linting tools and only allows commits if these checks pass.

Automation of code quality checks:

* Added `.githooks/pre-commit` script to automatically format staged backend Java files using `spotlessApply` via Gradle, and re-stage them if formatting succeeds.
* Integrated frontend formatting with Prettier and linting with ESLint for staged files, including automatic fixes and re-staging of files after successful checks.
* Script exits and prevents commit if any formatting or linting step fails, enforcing code standards before changes are committed.