### PR TITLE
Issue/#32 Allow users to fill in letters in game grid

### DIFF
--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -45,6 +45,21 @@ export default function SanaboksiGameGrid() {
     }
   };
 
+  const handleFieldChange = (
+    rowIndex: number, // The row to update
+    columnIndex: number, // The column to update
+    value: string, // The value to update
+  ) => {
+    setGameGrid((gameGrid) => {
+      const newGameGrid = gameGrid.map((row, i) =>
+        i === rowIndex
+          ? row.map((field, j) => (j === columnIndex ? value : field))
+          : row,
+      );
+      return newGameGrid;
+    });
+  };
+
   // Fetch fixed letters on component mount
   useEffect(() => {
     const initialFetch = async () => {
@@ -60,7 +75,7 @@ export default function SanaboksiGameGrid() {
           Array.from({ length: wordLength }).map((_, index) => (
             <SanaboksiGameRow
               key={index}
-              isEmpty={true}
+              isPlaceholder={true}
               rowLength={wordLength}
             />
           ))
@@ -71,6 +86,9 @@ export default function SanaboksiGameGrid() {
               fixedLetter={fixedLetter}
               rowData={gameGrid[rowIndex]}
               rowLength={wordLength}
+              onFieldChange={(columnIndex, value) =>
+                handleFieldChange(rowIndex, columnIndex, value)
+              }
             />
           ))}
     </>

--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -50,8 +50,11 @@ export default function SanaboksiGameGrid() {
     columnIndex: number, // The column to update
     value: string, // The value to update
   ) => {
-    setGameGrid((gameGrid) => {
-      const newGameGrid = gameGrid.map((row, i) =>
+    // Only allow single letter strings
+    if (typeof value !== "string" || value.length > 1) return;
+
+    setGameGrid((currentGameGrid) => {
+      const newGameGrid = currentGameGrid.map((row, i) =>
         i === rowIndex
           ? row.map((field, j) => (j === columnIndex ? value : field))
           : row,
@@ -67,6 +70,10 @@ export default function SanaboksiGameGrid() {
     };
     initialFetch();
   }, []);
+
+  useEffect(() => {
+    console.log(gameGrid);
+  }, [gameGrid]);
 
   return (
     <>

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -4,28 +4,30 @@ import type { FixedLetter } from "../types/Types";
 interface SanaboksiGameRowProps {
   fixedLetter?: FixedLetter;
   rowData?: string[];
-  isEmpty?: boolean;
+  isPlaceholder?: boolean;
   rowLength: number;
+  onFieldChange?: (columnIndex: number, value: string) => void;
 }
 
 export default function SanaboksiGameRow({
   fixedLetter,
   rowData = [],
-  isEmpty = false,
+  isPlaceholder = false,
   rowLength,
+  onFieldChange,
 }: SanaboksiGameRowProps) {
   return (
     <Group>
       {Array.from({ length: rowLength }).map((_, columnIndex) => {
         const isFixedLetter =
           fixedLetter && columnIndex === fixedLetter.fixedIndex;
-        const cellValue = isEmpty ? "" : (rowData[columnIndex] ?? "");
+        const cellValue = isPlaceholder ? "" : (rowData[columnIndex] ?? "");
 
         return (
           <TextInput
             key={columnIndex}
             value={cellValue}
-            readOnly={isEmpty || isFixedLetter}
+            readOnly={isPlaceholder || isFixedLetter}
             maxLength={1}
             w={50}
             styles={{
@@ -36,6 +38,12 @@ export default function SanaboksiGameRow({
                 backgroundColor: isFixedLetter ? "#f0f0f0" : "white",
               },
             }}
+            onChange={
+              !isPlaceholder && !isFixedLetter && onFieldChange
+                ? (event) =>
+                    onFieldChange(columnIndex, event.target.value.toUpperCase())
+                : undefined
+            }
           />
         );
       })}

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../types/Types";
 
@@ -16,6 +17,33 @@ export default function SanaboksiGameRow({
   rowLength,
   onFieldChange,
 }: SanaboksiGameRowProps) {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const handleChange = (columnIndex: number, value: string) => {
+    onFieldChange?.(columnIndex, value);
+
+    // Only move focus when a non-empty character is entered
+    if (!value) {
+      return;
+    }
+    // Move focus to the next editable field in the same row
+    // Skip over the next field if it is a fixed letter (not editable)
+    // Continue skipping until an editable field is found or the end of the row is reached
+    let nextColumnIndex = columnIndex + 1;
+    while (
+      nextColumnIndex < rowLength &&
+      fixedLetter &&
+      nextColumnIndex === fixedLetter.fixedIndex
+    ) {
+      nextColumnIndex++;
+    }
+
+    // Focus the next editable field, if it exists
+    if (nextColumnIndex < rowLength) {
+      inputRefs.current[nextColumnIndex]?.focus();
+    }
+  };
+
   return (
     <Group>
       {Array.from({ length: rowLength }).map((_, columnIndex) => {
@@ -30,6 +58,9 @@ export default function SanaboksiGameRow({
             readOnly={isPlaceholder || isFixedLetter}
             maxLength={1}
             w={50}
+            ref={(el) => {
+              inputRefs.current[columnIndex] = el;
+            }}
             styles={{
               input: {
                 textAlign: "center",
@@ -41,7 +72,7 @@ export default function SanaboksiGameRow({
             onChange={
               !isPlaceholder && !isFixedLetter && onFieldChange
                 ? (event) =>
-                    onFieldChange(columnIndex, event.target.value.toUpperCase())
+                    handleChange(columnIndex, event.target.value.toUpperCase())
                 : undefined
             }
           />

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import type { KeyboardEvent } from "react";
 import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../types/Types";
 
@@ -44,6 +45,28 @@ export default function SanaboksiGameRow({
     }
   };
 
+  const handleKeyDown = (
+    columnIndex: number,
+    event: KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (
+      (event.key === "Backspace" || event.key === "Delete") &&
+      !rowData[columnIndex]
+    ) {
+      let previousColumnIndex = columnIndex - 1;
+      while (
+        previousColumnIndex >= 0 &&
+        fixedLetter &&
+        previousColumnIndex === fixedLetter.fixedIndex
+      ) {
+        previousColumnIndex--;
+      }
+      if (previousColumnIndex >= 0) {
+        inputRefs.current[previousColumnIndex]?.focus();
+      }
+    }
+  };
+
   return (
     <Group>
       {Array.from({ length: rowLength }).map((_, columnIndex) => {
@@ -73,6 +96,11 @@ export default function SanaboksiGameRow({
               !isPlaceholder && !isFixedLetter && onFieldChange
                 ? (event) =>
                     handleChange(columnIndex, event.target.value.toUpperCase())
+                : undefined
+            }
+            onKeyDown={
+              !isPlaceholder && !isFixedLetter && onFieldChange
+                ? (event) => handleKeyDown(columnIndex, event)
                 : undefined
             }
           />

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -22,9 +22,10 @@ export default function SanaboksiGameRow({
 
   const handleChange = (columnIndex: number, value: string) => {
     // Only allow a single letter (A-Z + Ü, Å Ä and Ö, case-insensitive)
-    if (!/^[A-ZÜÅÄÖ]$/i.test(value)) {
+    if (value !== "" && !/^[A-ZÜÅÄÖ]$/i.test(value)) {
       return;
     }
+
     onFieldChange?.(columnIndex, value);
 
     // Only move focus when a non-empty character is entered

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -27,15 +27,13 @@ export default function SanaboksiGameRow({
     if (!value) {
       return;
     }
+
     // Move focus to the next editable field in the same row
     // Skip over the next field if it is a fixed letter (not editable)
     // Continue skipping until an editable field is found or the end of the row is reached
     let nextColumnIndex = columnIndex + 1;
-    while (
-      nextColumnIndex < rowLength &&
-      fixedLetter &&
-      nextColumnIndex === fixedLetter.fixedIndex
-    ) {
+
+    if (fixedLetter && nextColumnIndex === fixedLetter.fixedIndex) {
       nextColumnIndex++;
     }
 
@@ -54,13 +52,11 @@ export default function SanaboksiGameRow({
       !rowData[columnIndex]
     ) {
       let previousColumnIndex = columnIndex - 1;
-      while (
-        previousColumnIndex >= 0 &&
-        fixedLetter &&
-        previousColumnIndex === fixedLetter.fixedIndex
-      ) {
+
+      if (fixedLetter && previousColumnIndex === fixedLetter.fixedIndex) {
         previousColumnIndex--;
       }
+
       if (previousColumnIndex >= 0) {
         inputRefs.current[previousColumnIndex]?.focus();
       }

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -21,6 +21,10 @@ export default function SanaboksiGameRow({
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   const handleChange = (columnIndex: number, value: string) => {
+    // Only allow a single letter (A-Z + Ü, Å Ä and Ö, case-insensitive)
+    if (!/^[A-ZÜÅÄÖ]$/i.test(value)) {
+      return;
+    }
     onFieldChange?.(columnIndex, value);
 
     // Only move focus when a non-empty character is entered


### PR DESCRIPTION
Closes #32 
This pull request introduces significant improvements to the `SanaboksiGameGrid` and `SanaboksiGameRow` components, focusing on enabling interactive editing of the game grid and enhancing keyboard navigation for a better user experience. The main changes include implementing per-cell editing, handling focus movement between input fields, and improving the placeholder logic.

**Interactive Editing and Input Handling:**

* Added a new `handleFieldChange` function in `SanaboksiGameGrid` to update individual cells in the game grid state when a user types in an input field.
* Passed an `onFieldChange` callback from `SanaboksiGameGrid` to each `SanaboksiGameRow`, enabling rows to notify the parent grid about changes in their fields.

**Keyboard Navigation and Focus Management:**

* In `SanaboksiGameRow`, implemented logic to automatically move the focus to the next editable field after a character is entered, and to the previous editable field when backspace/delete is pressed on an empty field. This skips over fixed letters and respects row boundaries.
* Used `useRef` to keep references to all input fields in a row, enabling programmatic focus control.

**Placeholder and Prop Renaming Improvements:**

* Renamed the `isEmpty` prop to `isPlaceholder` in both `SanaboksiGameGrid` and `SanaboksiGameRow` for clarity, and updated related logic to use this new prop name. [[1]](diffhunk://#diff-48bc7ef7b01ffc541f94e3afaecb236c7922b4edad9b1b5049a76e82ac2f71baL63-R78) [[2]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR1-R86)
* Updated input fields to be read-only when they are placeholders or fixed letters, and ensured placeholder rows display as empty. [[1]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR1-R86) [[2]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR95-R105)