### PR TITLE
Issue/#33 Users can send a filled game grid for validation

### DIFF
--- a/backend/src/main/java/backend/configuration/CorsConfig.java
+++ b/backend/src/main/java/backend/configuration/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig {
   public CorsConfigurationSource getCorsConfigurationSource() {
     CorsConfiguration corsConfig = new CorsConfiguration();
     corsConfig.setAllowedOrigins(List.of(corsAllowedOrigin));
-    corsConfig.setAllowedMethods(List.of("GET"));
+    corsConfig.setAllowedMethods(List.of("GET", "POST"));
     corsConfig.setAllowedHeaders(List.of("Content-Type"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/java/backend/controller/GameController.java
+++ b/backend/src/main/java/backend/controller/GameController.java
@@ -5,6 +5,7 @@ import backend.dto.FixedLetterResponse;
 import backend.dto.GameGridRequest;
 import backend.dto.ValidationResultResponse;
 import backend.service.GameService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +32,7 @@ public class GameController {
 
   @PostMapping("/validation/{language}")
   public ResponseEntity<ValidationResultResponse> validateResults(
-      @RequestBody GameGridRequest gameGridRequest, @PathVariable Language language) {
+      @Valid @RequestBody GameGridRequest gameGridRequest, @PathVariable Language language) {
     return ResponseEntity.ok(gameService.validateGameGrid(gameGridRequest, language));
   }
 }

--- a/backend/src/main/java/backend/controller/GameController.java
+++ b/backend/src/main/java/backend/controller/GameController.java
@@ -2,10 +2,14 @@ package backend.controller;
 
 import backend.domain.Language;
 import backend.dto.FixedLetterResponse;
+import backend.dto.GameGridRequest;
+import backend.dto.ValidationResultResponse;
 import backend.service.GameService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +27,11 @@ public class GameController {
   public ResponseEntity<FixedLetterResponse> getFixedLetters(
       @PathVariable Language language, @PathVariable int wordLength, @PathVariable int wordCount) {
     return ResponseEntity.ok(gameService.getFixedLetterResponse(language, wordLength, wordCount));
+  }
+
+  @PostMapping("/validation/{language}")
+  public ResponseEntity<ValidationResultResponse> validateResults(
+      @RequestBody GameGridRequest gameGridRequest, @PathVariable Language language) {
+    return ResponseEntity.ok(gameService.validateGameGrid(gameGridRequest, language));
   }
 }

--- a/backend/src/main/java/backend/domain/Language.java
+++ b/backend/src/main/java/backend/domain/Language.java
@@ -1,5 +1,6 @@
 package backend.domain;
 
 public enum Language {
-  FI
+  FI,
+  UNKNOWN // This is used for testing purposes
 }

--- a/backend/src/main/java/backend/dto/GameGridRequest.java
+++ b/backend/src/main/java/backend/dto/GameGridRequest.java
@@ -1,6 +1,7 @@
 package backend.dto;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,5 +14,5 @@ import lombok.Setter;
 public class GameGridRequest {
 
   @NotNull(message = "Game grid cannot be null.")
-  private String[][] gameGrid;
+  private List<List<String>> gameGrid;
 }

--- a/backend/src/main/java/backend/dto/GameGridRequest.java
+++ b/backend/src/main/java/backend/dto/GameGridRequest.java
@@ -1,0 +1,17 @@
+package backend.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class GameGridRequest {
+
+  @NotNull(message = "Game grid cannot be null.")
+  private String[][] gameGrid;
+}

--- a/backend/src/main/java/backend/dto/ValidationResultResponse.java
+++ b/backend/src/main/java/backend/dto/ValidationResultResponse.java
@@ -1,0 +1,23 @@
+package backend.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationResultResponse {
+
+  private Map<
+          @Min(value = 0, message = "Validation result row index minimum value is 0.")
+          @Max(value = 6, message = "Validation result row index maximum value is 6.") Integer,
+          @NotNull(message = "Validation result must be true or false, not null.") Boolean>
+      validationResults;
+}

--- a/backend/src/main/java/backend/repository/FinnishWordRepository.java
+++ b/backend/src/main/java/backend/repository/FinnishWordRepository.java
@@ -20,7 +20,7 @@ public interface FinnishWordRepository extends JpaRepository<FinnishWord, Long> 
   int countByWordLength(@Param("wordLength") int wordLength);
 
   @Query(
-      value = "SELECT EXISTS (SELECT 1 FROM finnish_words WHERE word = :word)",
+      value = "SELECT EXISTS (SELECT 1 FROM finnish_words WHERE LOWER(word) = LOWER(:word))",
       nativeQuery = true)
   boolean validateWord(@Param("word") String word);
 }

--- a/backend/src/main/java/backend/repository/FinnishWordRepository.java
+++ b/backend/src/main/java/backend/repository/FinnishWordRepository.java
@@ -18,4 +18,9 @@ public interface FinnishWordRepository extends JpaRepository<FinnishWord, Long> 
       value = "SELECT COUNT(*) FROM finnish_words WHERE LENGTH(word) = :wordLength",
       nativeQuery = true)
   int countByWordLength(@Param("wordLength") int wordLength);
+
+  @Query(
+      value = "SELECT EXISTS (SELECT 1 FROM finnish_words WHERE word = :word)",
+      nativeQuery = true)
+  boolean validateWord(@Param("word") String word);
 }

--- a/backend/src/main/java/backend/service/GameService.java
+++ b/backend/src/main/java/backend/service/GameService.java
@@ -4,6 +4,8 @@ import backend.domain.FixedLetter;
 import backend.domain.Language;
 import backend.domain.entities.Word;
 import backend.dto.FixedLetterResponse;
+import backend.dto.GameGridRequest;
+import backend.dto.ValidationResultResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -71,5 +73,14 @@ public class GameService {
     fixedLetterResponse.setWordLength(wordLength);
 
     return fixedLetterResponse;
+  }
+
+  public ValidationResultResponse validateGameGrid(
+      GameGridRequest gameGridRequest, Language language) {
+    List<String> gameGridWords = utilityService.getGameGridWords(gameGridRequest);
+    ValidationResultResponse validationResultResponse =
+        repositoryService.validateWords(gameGridWords, language);
+
+    return validationResultResponse;
   }
 }

--- a/backend/src/main/java/backend/service/RepositoryService.java
+++ b/backend/src/main/java/backend/service/RepositoryService.java
@@ -70,7 +70,7 @@ public class RepositoryService {
     Boolean result;
 
     switch (language) {
-      case FI:
+      case Language.FI:
         for (int i = 0; i < gameGridWords.size(); i++) {
           result = finnishWordRepository.validateWord(gameGridWords.get(i));
           resultsMap.put(i, result);

--- a/backend/src/main/java/backend/service/RepositoryService.java
+++ b/backend/src/main/java/backend/service/RepositoryService.java
@@ -2,8 +2,10 @@ package backend.service;
 
 import backend.domain.Language;
 import backend.domain.entities.Word;
+import backend.dto.ValidationResultResponse;
 import backend.repository.FinnishWordRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -60,5 +62,26 @@ public class RepositoryService {
     }
 
     return wordCount;
+  }
+
+  public ValidationResultResponse validateWords(List<String> gameGridWords, Language language) {
+    ValidationResultResponse validationResultResponse = new ValidationResultResponse();
+    HashMap<Integer, Boolean> resultsMap = new HashMap<>();
+    Boolean result;
+
+    switch (language) {
+      case FI:
+        for (int i = 0; i < gameGridWords.size(); i++) {
+          result = finnishWordRepository.validateWord(gameGridWords.get(i));
+          resultsMap.put(i, result);
+        }
+        break;
+      default:
+        throw new RuntimeException("Unknown language: " + language);
+    }
+
+    validationResultResponse.setValidationResults(resultsMap);
+
+    return validationResultResponse;
   }
 }

--- a/backend/src/main/java/backend/service/UtilityService.java
+++ b/backend/src/main/java/backend/service/UtilityService.java
@@ -1,5 +1,8 @@
 package backend.service;
 
+import backend.dto.GameGridRequest;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.stereotype.Service;
 
@@ -17,5 +20,21 @@ public class UtilityService {
 
     // Returns an int between 0 (inclusive) and count (exclusive)
     return ThreadLocalRandom.current().nextInt(count);
+  }
+
+  public List<String> getGameGridWords(GameGridRequest gameGridRequest) {
+    String[][] gameGrid = gameGridRequest.getGameGrid();
+    List<String> gameGridWords = new ArrayList<>();
+    StringBuilder stringBuilder = new StringBuilder();
+
+    for (int rowIndex = 0; rowIndex < gameGrid.length; rowIndex++) {
+      for (int columnIndex = 0; columnIndex < gameGrid[rowIndex].length; columnIndex++) {
+        stringBuilder.append(gameGrid[rowIndex][columnIndex]);
+      }
+      gameGridWords.add(stringBuilder.toString().toLowerCase());
+      stringBuilder.setLength(0);
+    }
+
+    return gameGridWords;
   }
 }

--- a/backend/src/main/java/backend/service/UtilityService.java
+++ b/backend/src/main/java/backend/service/UtilityService.java
@@ -23,14 +23,34 @@ public class UtilityService {
   }
 
   public List<String> getGameGridWords(GameGridRequest gameGridRequest) {
-    String[][] gameGrid = gameGridRequest.getGameGrid();
+    if (gameGridRequest == null) {
+      throw new IllegalArgumentException("GameGridRequest cannot be null.");
+    }
+
+    List<List<String>> gameGrid = gameGridRequest.getGameGrid();
+    if (gameGrid == null || gameGrid.isEmpty()) {
+      throw new IllegalArgumentException("Game grid cannot be null or empty.");
+    }
+
     List<String> gameGridWords = new ArrayList<>();
     StringBuilder stringBuilder = new StringBuilder();
 
-    for (int rowIndex = 0; rowIndex < gameGrid.length; rowIndex++) {
-      for (int columnIndex = 0; columnIndex < gameGrid[rowIndex].length; columnIndex++) {
-        stringBuilder.append(gameGrid[rowIndex][columnIndex]);
+    for (int rowIndex = 0; rowIndex < gameGrid.size(); rowIndex++) {
+      List<String> row = gameGrid.get(rowIndex);
+      if (row == null || row.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Row with index " + rowIndex + " in game grid cannot be null or empty.");
       }
+
+      for (int columnIndex = 0; columnIndex < row.size(); columnIndex++) {
+        String cell = row.get(columnIndex);
+        if (cell == null) {
+          throw new IllegalArgumentException(
+              "Cell at row " + rowIndex + " with column index " + columnIndex + " cannot be null.");
+        }
+        stringBuilder.append(cell);
+      }
+
       gameGridWords.add(stringBuilder.toString().toLowerCase());
       stringBuilder.setLength(0);
     }

--- a/backend/src/main/java/backend/service/UtilityService.java
+++ b/backend/src/main/java/backend/service/UtilityService.java
@@ -44,9 +44,13 @@ public class UtilityService {
 
       for (int columnIndex = 0; columnIndex < row.size(); columnIndex++) {
         String cell = row.get(columnIndex);
-        if (cell == null) {
+        if (cell == null || cell.equals("")) {
           throw new IllegalArgumentException(
-              "Cell at row " + rowIndex + " with column index " + columnIndex + " cannot be null.");
+              "Cell at row "
+                  + rowIndex
+                  + " with column index "
+                  + columnIndex
+                  + " cannot be null or empty.");
         }
         stringBuilder.append(cell);
       }

--- a/backend/src/test/java/backend/unit/GameServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/GameServiceUnitTests.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import backend.domain.Language;
 import backend.domain.entities.FinnishWord;
 import backend.domain.entities.Word;
 import backend.dto.FixedLetterResponse;
+import backend.dto.GameGridRequest;
+import backend.dto.ValidationResultResponse;
 import backend.service.GameService;
 import backend.service.RepositoryService;
 import backend.service.UtilityService;
@@ -68,6 +71,10 @@ public class GameServiceUnitTests {
         gameService.getFixedLetterResponse(language, wordLength, requestedWordCount);
 
     assertEquals(wordRepositorySize, fixedLetterResponse.getFixedLetters().size());
+    verify(mockRepositoryService)
+        .getRepositoryCountForWordsWithCorrectLanguageAndLength(language, wordLength);
+    verify(mockRepositoryService)
+        .findRandomWordsWithCorrectLanguageLengthAndCount(eq(language), eq(wordLength), anyInt());
   }
 
   @Test
@@ -79,14 +86,12 @@ public class GameServiceUnitTests {
     assertThrows(
         IllegalStateException.class,
         () -> gameService.getFixedLetterResponse(language, wordLength, wordCount));
+    verify(mockRepositoryService)
+        .getRepositoryCountForWordsWithCorrectLanguageAndLength(language, wordLength);
   }
 
   @Test
   public void getFixedLetterResponseShouldThrowExceptionIfRequestedWordCountIsNegative() {
-    when(mockRepositoryService.getRepositoryCountForWordsWithCorrectLanguageAndLength(
-            language, wordLength))
-        .thenReturn(100);
-
     assertThrows(
         IllegalArgumentException.class,
         () -> gameService.getFixedLetterResponse(language, wordLength, -5));
@@ -94,10 +99,6 @@ public class GameServiceUnitTests {
 
   @Test
   public void getFixedLetterResponseShouldThrowExceptionIfRequestedWordCountIsZero() {
-    when(mockRepositoryService.getRepositoryCountForWordsWithCorrectLanguageAndLength(
-            language, wordLength))
-        .thenReturn(100);
-
     assertThrows(
         IllegalArgumentException.class,
         () -> gameService.getFixedLetterResponse(language, wordLength, 0));
@@ -135,6 +136,10 @@ public class GameServiceUnitTests {
         gameService.getFixedLetterResponse(language, wordLength, requestedWordCount);
 
     assertEquals(requestedWordCount, fixedLetterResponse.getFixedLetters().size());
+    verify(mockRepositoryService)
+        .getRepositoryCountForWordsWithCorrectLanguageAndLength(language, wordLength);
+    verify(mockRepositoryService)
+        .findRandomWordsWithCorrectLanguageLengthAndCount(language, wordLength, requestedWordCount);
   }
 
   @Test
@@ -192,5 +197,40 @@ public class GameServiceUnitTests {
     // Verify fifth word "phone" at index 0 -> 'p'
     assertEquals(0, fixedLetters.getFixedLetters().get(4).getFixedIndex());
     assertEquals('p', fixedLetters.getFixedLetters().get(4).getFixedLetter());
+
+    verify(mockRepositoryService)
+        .getRepositoryCountForWordsWithCorrectLanguageAndLength(language, wordLength);
+    verify(mockRepositoryService)
+        .findRandomWordsWithCorrectLanguageLengthAndCount(language, wordLength, wordCount);
+  }
+
+  @Test
+  public void getFixedLetterResponseShouldThrowExceptionIfWordLengthIsTooShort() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> gameService.getFixedLetterResponse(language, 4, wordCount));
+  }
+
+  @Test
+  public void getFixedLetterResponseShouldThrowExceptionIfWordLengthIsTooLong() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> gameService.getFixedLetterResponse(language, 8, wordCount));
+  }
+
+  @Test
+  public void validateGameGridShouldReturnValidationResultResponse() {
+    GameGridRequest mockRequest = mock(GameGridRequest.class);
+    ValidationResultResponse mockResponse = mock(ValidationResultResponse.class);
+    List<String> mockWords = List.of("vehnä", "suola", "maito", "kahvi", "kerma");
+
+    when(mockUtilityService.getGameGridWords(mockRequest)).thenReturn(mockWords);
+    when(mockRepositoryService.validateWords(mockWords, language)).thenReturn(mockResponse);
+
+    ValidationResultResponse response = gameService.validateGameGrid(mockRequest, language);
+
+    assertEquals(mockResponse, response);
+    verify(mockUtilityService).getGameGridWords(mockRequest);
+    verify(mockRepositoryService).validateWords(mockWords, language);
   }
 }

--- a/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
@@ -1,0 +1,139 @@
+package backend.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import backend.domain.Language;
+import backend.domain.entities.FinnishWord;
+import backend.domain.entities.Word;
+import backend.dto.ValidationResultResponse;
+import backend.repository.FinnishWordRepository;
+import backend.service.RepositoryService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryServiceUnitTests {
+
+  private RepositoryService repositoryService;
+  private FinnishWordRepository mockFinnishWordRepository;
+
+  @BeforeEach
+  public void setUpMockClasses() {
+    mockFinnishWordRepository = mock(FinnishWordRepository.class);
+    repositoryService = new RepositoryService(mockFinnishWordRepository);
+  }
+
+  @Test
+  public void findRandomWordsWithCorrectLanguageLengthAndCountShouldReturnWords() {
+    List<FinnishWord> mockWords = new ArrayList<>();
+    mockWords.add(new FinnishWord(1L, "vehnä"));
+    mockWords.add(new FinnishWord(2L, "maito"));
+
+    when(mockFinnishWordRepository.findRandomWordsByWordLengthAndCount(5, 2)).thenReturn(mockWords);
+
+    List<? extends Word> result =
+        repositoryService.findRandomWordsWithCorrectLanguageLengthAndCount(Language.FI, 5, 2);
+
+    assertEquals(mockWords, result);
+    verify(mockFinnishWordRepository).findRandomWordsByWordLengthAndCount(5, 2);
+  }
+
+  @Test
+  public void
+      findRandomWordsWithCorrectLanguageLengthAndCountShouldThrowExceptionIfLanguageIsUnknown() {
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            repositoryService.findRandomWordsWithCorrectLanguageLengthAndCount(
+                Language.UNKNOWN, 5, 5));
+  }
+
+  @Test
+  public void
+      findRandomWordsWithCorrectLanguageLengthAndCountShouldThrowExceptionIfWordRepositoryIsNull() {
+    when(mockFinnishWordRepository.findRandomWordsByWordLengthAndCount(5, 5)).thenReturn(null);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            repositoryService.findRandomWordsWithCorrectLanguageLengthAndCount(Language.FI, 5, 5));
+    verify(mockFinnishWordRepository).findRandomWordsByWordLengthAndCount(5, 5);
+  }
+
+  @Test
+  public void
+      findRandomWordsWithCorrectLanguageLengthAndCountShouldThrowExceptionIfWordRepositoryIsEmpty() {
+    when(mockFinnishWordRepository.findRandomWordsByWordLengthAndCount(5, 5))
+        .thenReturn(Arrays.asList());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            repositoryService.findRandomWordsWithCorrectLanguageLengthAndCount(Language.FI, 5, 5));
+    verify(mockFinnishWordRepository).findRandomWordsByWordLengthAndCount(5, 5);
+  }
+
+  @Test
+  public void getRepositoryCountForWordsWithCorrectLanguageAndLengthShouldReturnCount() {
+    when(mockFinnishWordRepository.countByWordLength(5)).thenReturn(42);
+
+    int result =
+        repositoryService.getRepositoryCountForWordsWithCorrectLanguageAndLength(Language.FI, 5);
+
+    assertEquals(42, result);
+    verify(mockFinnishWordRepository).countByWordLength(5);
+  }
+
+  @Test
+  public void
+      getRepositoryCountForWordsWithCorrectLanguageAndLengthShouldThrowExceptionIfLanguageIsUnknown() {
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            repositoryService.findRandomWordsWithCorrectLanguageLengthAndCount(
+                Language.UNKNOWN, 5, 5));
+  }
+
+  @Test
+  public void
+      getRepositoryCountForWordsWithCorrectLanguageAndLengthShouldThrowExceptionIfWordRepositoryIsEmpty() {
+    when(mockFinnishWordRepository.countByWordLength(5)).thenReturn(0);
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            repositoryService.getRepositoryCountForWordsWithCorrectLanguageAndLength(
+                Language.FI, 5));
+    verify(mockFinnishWordRepository).countByWordLength(5);
+  }
+
+  @Test
+  public void validateWordsShouldReturnValidationResultResponse() {
+    List<String> testWords = Arrays.asList("vehnä", "maito");
+    when(mockFinnishWordRepository.validateWord("vehnä")).thenReturn(true);
+    when(mockFinnishWordRepository.validateWord("maito")).thenReturn(false);
+
+    ValidationResultResponse response = repositoryService.validateWords(testWords, Language.FI);
+
+    // Check that the response contains the expected validation results
+    assertEquals(true, response.getValidationResults().get(0));
+    assertEquals(false, response.getValidationResults().get(1));
+    verify(mockFinnishWordRepository).validateWord("vehnä");
+    verify(mockFinnishWordRepository).validateWord("maito");
+  }
+
+  @Test
+  public void validateWordsShouldThrowExceptionIfLanguageIsUnknown() {
+    List<String> testWords = Arrays.asList("vehnä", "suola", "maito", "kahvi", "kerma");
+
+    assertThrows(
+        RuntimeException.class, () -> repositoryService.validateWords(testWords, Language.UNKNOWN));
+  }
+}

--- a/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import backend.dto.GameGridRequest;
 import backend.service.UtilityService;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class UtilityServiceUnitTests {
@@ -43,5 +46,95 @@ public class UtilityServiceUnitTests {
         assertThrows(IllegalArgumentException.class, () -> utilityService.getRandomIndex(count));
 
     assertEquals(expectedExceptionMessage, exception.getMessage());
+  }
+
+  @Test
+  public void getGameGridWordsShouldReturnCorrectWords() {
+    List<String> testWords = Arrays.asList("vehnä", "suola", "maito", "kahvi", "kerma");
+    List<List<String>> testGrid =
+        Arrays.asList(
+            Arrays.asList("V", "E", "H", "N", "Ä"),
+            Arrays.asList("S", "U", "O", "L", "A"),
+            Arrays.asList("M", "A", "I", "T", "O"),
+            Arrays.asList("K", "A", "H", "V", "I"),
+            Arrays.asList("K", "E", "R", "M", "A"));
+
+    GameGridRequest testRequest = new GameGridRequest(testGrid);
+    assertEquals(testWords, utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridRequestIsNull() {
+    assertThrows(IllegalArgumentException.class, () -> utilityService.getGameGridWords(null));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridIsNull() {
+    GameGridRequest testRequest = new GameGridRequest(null);
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridIsEmpty() {
+    GameGridRequest testRequest = new GameGridRequest(Arrays.asList());
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridRowIsNull() {
+    GameGridRequest testRequest =
+        new GameGridRequest(
+            Arrays.asList(
+                Arrays.asList("V", "E", "H", "N", "Ä"),
+                Arrays.asList("S", "U", "O", "L", "A"),
+                Arrays.asList("M", "A", "I", "T", "O"),
+                Arrays.asList("K", "A", "H", "V", "I"),
+                null));
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridRowIsEmpty() {
+    GameGridRequest testRequest =
+        new GameGridRequest(
+            Arrays.asList(
+                Arrays.asList("V", "E", "H", "N", "Ä"),
+                Arrays.asList("S", "U", "O", "L", "A"),
+                Arrays.asList("M", "A", "I", "T", "O"),
+                Arrays.asList("K", "A", "H", "V", "I"),
+                Arrays.asList()));
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridCellIsNull() {
+    GameGridRequest testRequest =
+        new GameGridRequest(
+            Arrays.asList(
+                Arrays.asList("V", "E", "H", "N", "Ä"),
+                Arrays.asList("S", "U", "O", "L", "A"),
+                Arrays.asList("M", "A", "I", "T", "O"),
+                Arrays.asList("K", "A", "H", "V", "I"),
+                Arrays.asList("K", "E", "R", "M", null)));
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void getGameGridWordsShouldThrowExceptionIfGameGridCellIsEmptyl() {
+    GameGridRequest testRequest =
+        new GameGridRequest(
+            Arrays.asList(
+                Arrays.asList("V", "E", "H", "N", "Ä"),
+                Arrays.asList("S", "U", "O", "L", "A"),
+                Arrays.asList("M", "A", "I", "T", "O"),
+                Arrays.asList("K", "A", "H", "V", "I"),
+                Arrays.asList("K", "E", "R", "M", "")));
+    assertThrows(
+        IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
   }
 }

--- a/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
@@ -125,7 +125,7 @@ public class UtilityServiceUnitTests {
   }
 
   @Test
-  public void getGameGridWordsShouldThrowExceptionIfGameGridCellIsEmptyl() {
+  public void getGameGridWordsShouldThrowExceptionIfGameGridCellIsEmpty() {
     GameGridRequest testRequest =
         new GameGridRequest(
             Arrays.asList(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mantine/core": "^8.3.14",
+        "@tabler/icons-react": "^3.36.1",
         "axios": "^1.13.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1458,6 +1459,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.36.1.tgz",
+      "integrity": "sha512-f4Jg3Fof/Vru5ioix/UO4GX+sdDsF9wQo47FbtvG+utIYYVQ/QVAC0QYgcBbAjQGfbdOh2CCf0BgiFOF9Ixtjw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.36.1.tgz",
+      "integrity": "sha512-/8nOXeNeMoze9xY/QyEKG65wuvRhkT3q9aytaur6Gj8bYU2A98YVJyLc9MRmc5nVvpy+bRlrrwK/Ykr8WGyUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": ""
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@mantine/core": "^8.3.14",
+    "@tabler/icons-react": "^3.36.1",
     "axios": "^1.13.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/frontend/src/api/Api.tsx
+++ b/frontend/src/api/Api.tsx
@@ -1,5 +1,9 @@
 import axios from "axios";
-import type { FixedLetterResponse } from "../types/Types";
+import type {
+  FixedLetterResponse,
+  GameGrid,
+  ValidationResults,
+} from "../types/Types";
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 
@@ -22,4 +26,29 @@ const getFixedLetters = async (
   }
 };
 
-export { getFixedLetters };
+const validateGameGrid = async (
+  gameGrid: GameGrid,
+  language: string,
+): Promise<ValidationResults | undefined> => {
+  const languageEnum = language.toUpperCase();
+  try {
+    const response = await axios.post(
+      `${SERVER_URL}/api/validation/${languageEnum}`,
+      {
+        gameGrid,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+  }
+};
+
+export { getFixedLetters, validateGameGrid };

--- a/frontend/src/api/Api.tsx
+++ b/frontend/src/api/Api.tsx
@@ -43,7 +43,7 @@ const validateGameGrid = async (
         },
       },
     );
-    return response.data;
+    return response.data.validationResults;
   } catch (error: unknown) {
     if (error instanceof Error) {
       throw new Error(error.message);

--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -67,6 +67,19 @@ export default function SanaboksiGameGrid() {
     });
   };
 
+  const handleGameGridValidation = async () => {
+    try {
+      const validationResultsData = await validateGameGrid(gameGrid, "fi");
+      setValidationResults(validationResultsData);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      } else {
+        throw new Error("Failed to handle game grid validation: Unknown error");
+      }
+    }
+  };
+
   // Fetch fixed letters on component mount
   useEffect(() => {
     const initialFetch = async () => {
@@ -83,11 +96,6 @@ export default function SanaboksiGameGrid() {
   useEffect(() => {
     console.log("validationResults:", validationResults);
   }, [validationResults]);
-
-  const handleGameGridValidation = async () => {
-    const validationResultsData = await validateGameGrid(gameGrid, "fi");
-    setValidationResults(validationResultsData);
-  };
 
   return (
     <>

--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import type { FixedLetters, GameGrid } from "../types/Types";
+import type { FixedLetters, GameGrid, ValidationResults } from "../types/Types";
 import { getFixedLetters, validateGameGrid } from "../api/Api";
 import SanaboksiGameRow from "./SanaboksiGameRow";
 import { Button } from "@mantine/core";
@@ -10,6 +10,9 @@ export default function SanaboksiGameGrid() {
   // Store the actual game grid data (2D array of characters with dynamic dimensions)
   const [gameGrid, setGameGrid] = useState<GameGrid>([]);
   const [wordLength, setWordLength] = useState<number>(5);
+  const [validationResults, setValidationResults] = useState<
+    ValidationResults | undefined
+  >(undefined);
 
   /**
    * Fetches fixed letters from the API and initializes the game grid
@@ -67,18 +70,23 @@ export default function SanaboksiGameGrid() {
   // Fetch fixed letters on component mount
   useEffect(() => {
     const initialFetch = async () => {
-      await fetchFixedLetters("fi", 7, 5);
+      await fetchFixedLetters("fi", 5, 5);
     };
     initialFetch();
   }, []);
 
+  // Console.logs for dev, remove when deployed to production
   useEffect(() => {
-    console.log(gameGrid);
+    console.log("gameGrid:", gameGrid);
   }, [gameGrid]);
 
+  useEffect(() => {
+    console.log("validationResults:", validationResults);
+  }, [validationResults]);
+
   const handleGameGridValidation = async () => {
-    const validationResults = await validateGameGrid(gameGrid, "fi");
-    console.log(validationResults);
+    const validationResultsData = await validateGameGrid(gameGrid, "fi");
+    setValidationResults(validationResultsData);
   };
 
   return (
@@ -101,6 +109,11 @@ export default function SanaboksiGameGrid() {
               rowLength={wordLength}
               onFieldChange={(columnIndex, value) =>
                 handleFieldChange(rowIndex, columnIndex, value)
+              }
+              isCorrect={
+                validationResults
+                  ? validationResults[rowIndex.toString()]
+                  : undefined
               }
             />
           ))}

--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import type { FixedLetters, GameGrid } from "../types/Types";
-import { getFixedLetters } from "../api/Api";
+import { getFixedLetters, validateGameGrid } from "../api/Api";
 import SanaboksiGameRow from "./SanaboksiGameRow";
+import { Button } from "@mantine/core";
 
 export default function SanaboksiGameGrid() {
   // Store the fixed letters configuration for each row (which index has which fixed letter)
@@ -66,7 +67,7 @@ export default function SanaboksiGameGrid() {
   // Fetch fixed letters on component mount
   useEffect(() => {
     const initialFetch = async () => {
-      await fetchFixedLetters("fi", 5, 5);
+      await fetchFixedLetters("fi", 7, 5);
     };
     initialFetch();
   }, []);
@@ -74,6 +75,11 @@ export default function SanaboksiGameGrid() {
   useEffect(() => {
     console.log(gameGrid);
   }, [gameGrid]);
+
+  const handleGameGridValidation = async () => {
+    const validationResults = await validateGameGrid(gameGrid, "fi");
+    console.log(validationResults);
+  };
 
   return (
     <>
@@ -98,6 +104,7 @@ export default function SanaboksiGameGrid() {
               }
             />
           ))}
+      <Button onClick={handleGameGridValidation}>Validate game grid</Button>
     </>
   );
 }

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -9,6 +9,7 @@ interface SanaboksiGameRowProps {
   isPlaceholder?: boolean;
   rowLength: number;
   onFieldChange?: (columnIndex: number, value: string) => void;
+  isCorrect?: boolean;
 }
 
 export default function SanaboksiGameRow({
@@ -17,6 +18,7 @@ export default function SanaboksiGameRow({
   isPlaceholder = false,
   rowLength,
   onFieldChange,
+  isCorrect,
 }: SanaboksiGameRowProps) {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -74,6 +76,8 @@ export default function SanaboksiGameRow({
         const isFixedLetter =
           fixedLetter && columnIndex === fixedLetter.fixedIndex;
         const cellValue = isPlaceholder ? "" : (rowData[columnIndex] ?? "");
+        const correctBorderColor =
+          isCorrect === undefined ? "gray" : isCorrect ? "green" : "red";
 
         return (
           <TextInput
@@ -91,6 +95,7 @@ export default function SanaboksiGameRow({
                 fontSize: 24,
                 fontWeight: isFixedLetter ? "bold" : "normal",
                 backgroundColor: isFixedLetter ? "#f0f0f0" : "white",
+                borderColor: correctBorderColor,
               },
             }}
             onChange={

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import type { KeyboardEvent } from "react";
 import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../types/Types";
+import { IconCheck, IconX } from "@tabler/icons-react";
 
 interface SanaboksiGameRowProps {
   fixedLetter?: FixedLetter;
@@ -112,6 +113,8 @@ export default function SanaboksiGameRow({
           />
         );
       })}
+      {isCorrect !== undefined &&
+        (isCorrect ? <IconCheck color="green" /> : <IconX color="red" />)}
     </Group>
   );
 }

--- a/frontend/src/types/Types.tsx
+++ b/frontend/src/types/Types.tsx
@@ -12,5 +12,5 @@ export type FixedLetterResponse = {
 
 export type GameGrid = string[][];
 
-// {rowIndex : isCorrect}, i.e. correct row 1 -> {0, true}
-export type ValidationResults = Record<number, boolean>;
+// {rowIndex : isCorrect}, i.e. correct row 1 -> {"0", true}
+export type ValidationResults = Record<string, boolean>;

--- a/frontend/src/types/Types.tsx
+++ b/frontend/src/types/Types.tsx
@@ -11,3 +11,6 @@ export type FixedLetterResponse = {
 };
 
 export type GameGrid = string[][];
+
+// {rowIndex : isCorrect}, i.e. correct row 1 -> {0, true}
+export type ValidationResults = Record<number, boolean>;


### PR DESCRIPTION
Closes #33 
This pull request introduces a new backend validation API for checking the correctness of words in the game grid and integrates this feature into the frontend. The backend now accepts a grid of words, validates each row, and returns which rows are correct. The frontend provides a button to trigger validation and visual feedback for each row based on the validation result. Additionally, CORS is updated to support POST requests, and a new icon library is added for UI enhancements.

**Backend: Game grid validation API**

* Added a new endpoint `/api/validation/{language}` in `GameController` to accept a game grid and return validation results for each row.
* Implemented `GameGridRequest` and `ValidationResultResponse` DTOs to structure the request and response for the validation API. [[1]](diffhunk://#diff-d11e96f0e1e17ec7d34d94e3b28a1adb7e097780bdff9deec5ffaaa1d0c615a7R1-R17) [[2]](diffhunk://#diff-bd1a9f45fb640492ae4a1d91a13b5b8b9a85600a170d8d28a08403e7b7fff0cfR1-R23)
* Added logic in `GameService` and `RepositoryService` to extract words from the grid, validate them against the database, and return results. [[1]](diffhunk://#diff-7897b03298291a1a650a3598090c7ab6202fb2057a7cf787cddaea92e64a2a6bR77-R85) [[2]](diffhunk://#diff-b1b7da461414f71975e343c4860d46bf9081ae1d0d8d6e5530fe551f8c946bdfR66-R86) [[3]](diffhunk://#diff-89c0166459a6fbd7257dada476b9d4396a472fbb9f89bfb05cac43d446ca608dR24-R39)
* Updated `FinnishWordRepository` to include a method for checking if a word exists in the database.
* Allowed CORS POST requests to enable the new validation API from the frontend.

**Frontend: Integration and UI feedback**

* Added `validateGameGrid` API call and `ValidationResults` type to handle grid validation and responses. [[1]](diffhunk://#diff-5abaff83a199db052738926efc7f71e4868b15627369ac914db355b395460dd5L25-R54) [[2]](diffhunk://#diff-51eddc2463ad995c1fcec38b73af73426bf53388fb267d7fcc4ff031991ab369R14-R16)
* Updated `SanaboksiGameGrid` to include a "Validate game grid" button, call the backend, and store/display validation results for each row. [[1]](diffhunk://#diff-48bc7ef7b01ffc541f94e3afaecb236c7922b4edad9b1b5049a76e82ac2f71baR78-R91) [[2]](diffhunk://#diff-48bc7ef7b01ffc541f94e3afaecb236c7922b4edad9b1b5049a76e82ac2f71baR113-R120)
* Modified `SanaboksiGameRow` to visually indicate row correctness using border colors and icons. [[1]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR80-R81) [[2]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR99) [[3]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR116-R117)
* Added `@tabler/icons-react` for icon support in the UI. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R14) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR12) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR1463-R1488)

These changes collectively enable users to validate their game grid and receive immediate, clear feedback on which rows are correct.