### PR TITLE
Issue/#50 Review CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -68,6 +68,13 @@ jobs:
         run: |
           cd backend
           ./gradlew unitTest
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: unit-test-report
+          path: backend/build/reports/tests/unitTest/
   
   run-backend-integration-tests:
     name: BE integration tests
@@ -103,3 +110,10 @@ jobs:
         run: |
           cd backend
           ./gradlew integrationTest
+
+      - name: Upload integration test report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: integration-test-report
+          path: backend/build/reports/tests/integrationTest/

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -81,11 +81,11 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         ports:
           - 5432:5432
         env:
-          POSTGRES_DB: ${{ secrets.DATABASE_NAME }}
+          POSTGRES_DB: ${{ vars.DATABASE_NAME }}
           POSTGRES_USER: ${{ secrets.DATABASE_USER }}
           POSTGRES_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
         options: >-

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -72,6 +72,20 @@ jobs:
   run-backend-integration-tests:
     name: BE integration tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: ${{ secrets.DATABASE_NAME }}
+          POSTGRES_USER: ${{ secrets.DATABASE_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Checkout code
@@ -81,6 +95,11 @@ jobs:
         uses: ./.github/actions/setup-backend-workflow-environment
       
       - name: Run BE integration tests
+        env:
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USERNAME: ${{ secrets.DATABASE_USER }}
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          CORS_ALLOWED_ORIGIN: ${{ secrets.CORS_ALLOWED_ORIGIN }}
         run: |
           cd backend
           ./gradlew integrationTest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -69,8 +69,8 @@ jobs:
           cd backend
           ./gradlew unitTest
 
-      - name: Upload unit test report
-        if: always()
+      - name: Upload unit test report on test failure
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v6
         with:
           name: unit-test-report
@@ -111,8 +111,8 @@ jobs:
           cd backend
           ./gradlew integrationTest
 
-      - name: Upload integration test report
-        if: always()
+      - name: Upload integration test report on test failure
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v6
         with:
           name: integration-test-report

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,22 +48,24 @@ tasks.register('unitTest', Test) {
 	group = 'verification'
 	description = 'Runs only unit tests.'
 
-	useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
 
-	filter {
-		includeTestsMatching "backend.unit.*"
-	}
+	useJUnitPlatform {
+        includeTags 'unitTest'
+    }
 }
 
 tasks.register('integrationTest', Test) {
 	group = 'verification'
 	description = 'Runs only integration tests.'
 
-	useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
 
-	filter {
-		includeTestsMatching "backend.integration.*"
-	}
+	useJUnitPlatform {
+        includeTags 'integrationTest'
+    }
 }
 
 spotless {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -2,7 +2,8 @@ spring:
   application:
     name: backend
   datasource:
-    # Datasource variables come from compose.yaml
+    driver-class-name: org.postgresql.Driver
+    # Datasource variables come from compose.yaml or from GitHub secrets
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
   sql:
     init:
       mode: always
-      data-locations: classpath:data.sql
+      schema-locations: classpath:schema.sql
+      data-locations: [classpath:finnishWords/finnish-*-letter-words.sql]
 
 CorsAllowedOrigin: ${CORS_ALLOWED_ORIGIN}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -2,6 +2,6 @@ DROP TABLE IF EXISTS finnish_words;
 
 CREATE TABLE IF NOT EXISTS finnish_words
 (
-    id              BIGSERIAL PRIMARY KEY,
-    word            VARCHAR NOT NULL UNIQUE CHECK (LENGTH(word) >= 5 AND LENGTH(word) <= 7)
+    id      BIGSERIAL PRIMARY KEY,
+    word    VARCHAR NOT NULL UNIQUE CHECK (LENGTH(word) >= 5 AND LENGTH(word) <= 7)
 );

--- a/backend/src/test/java/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/backend/BackendApplicationTests.java
@@ -1,9 +1,11 @@
 package backend;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Tag("integrationTest")
 class BackendApplicationTests {
 
   @Test

--- a/backend/src/test/java/backend/integration/PlaceholderIntegrationTest.java
+++ b/backend/src/test/java/backend/integration/PlaceholderIntegrationTest.java
@@ -2,10 +2,12 @@ package backend.integration;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Tag("integrationTest")
 public class PlaceholderIntegrationTest {
 
   // A placeholder test to check that custom Gradle task runs

--- a/backend/src/test/java/backend/unit/GameServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/GameServiceUnitTests.java
@@ -20,8 +20,10 @@ import backend.service.UtilityService;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("unitTest")
 public class GameServiceUnitTests {
 
   private RepositoryService mockRepositoryService;

--- a/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
@@ -16,8 +16,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("unitTest")
 public class RepositoryServiceUnitTests {
 
   private RepositoryService repositoryService;

--- a/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
@@ -8,8 +8,10 @@ import backend.dto.GameGridRequest;
 import backend.service.UtilityService;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("unitTest")
 public class UtilityServiceUnitTests {
 
   private final UtilityService utilityService = new UtilityService();


### PR DESCRIPTION
Closes #50 
This pull request updates the test configuration in the backend to use JUnit 5 tags for distinguishing between unit and integration tests, and modifies the Gradle build script to use these tags in the custom test tasks. This change makes test selection more robust and maintainable.

**Test configuration improvements:**

* Added `@Tag("unitTest")` to all unit test classes (`GameServiceUnitTests`, `RepositoryServiceUnitTests`, `UtilityServiceUnitTests`) to clearly identify them as unit tests. [[1]](diffhunk://#diff-9a13db00b02a243c179e27ef495a5abcf50f3b381df6f5c107cf5571af78df0dR23-R26) [[2]](diffhunk://#diff-37001d7f7bcee9f445b195930c0f129dc7f232a0e301377d06d929e9a50c913cR19-R22) [[3]](diffhunk://#diff-738f8e92094433d2f201911cf2aafdca5737bc70da3473510f0a98c8fb16467aR11-R14)
* Added `@Tag("integrationTest")` to the integration test class (`PlaceholderIntegrationTest`) for proper classification.

**Gradle build script updates:**

* Updated the `unitTest` and `integrationTest` tasks in `backend/build.gradle` to use `useJUnitPlatform` with `includeTags` for selecting tests by their tags, instead of using test name patterns.