### PR TITLE
Issue/#59 User should not be able to edit fields after correct validation

### DIFF
--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -108,7 +108,7 @@ export default function SanaboksiGameRow({
           <TextInput
             key={columnIndex}
             value={cellValue}
-            readOnly={isPlaceholder || isFixedLetter}
+            readOnly={isPlaceholder || isFixedLetter || isCorrect}
             maxLength={1}
             w={50}
             ref={(el) => {


### PR DESCRIPTION
Closes #59 
This pull request introduces a minor update to the `SanaboksiGameRow` component to improve the user experience during gameplay. Now, input fields will also become read-only if the answer is already correct, in addition to the existing conditions.

- User input fields in `SanaboksiGameRow.tsx` are set to `readOnly` when the answer is correct, preventing further changes to solved cells.