### PR TITLE
Issue/#57 Players should not be able to input duplicate words

### DIFF
--- a/backend/src/main/java/backend/controller/GameController.java
+++ b/backend/src/main/java/backend/controller/GameController.java
@@ -31,7 +31,7 @@ public class GameController {
   }
 
   @PostMapping("/validation/{language}")
-  public ResponseEntity<ValidationResultResponse> validateResults(
+  public ResponseEntity<ValidationResultResponse> validateGameGrid(
       @Valid @RequestBody GameGridRequest gameGridRequest, @PathVariable Language language) {
     return ResponseEntity.ok(gameService.validateGameGrid(gameGridRequest, language));
   }

--- a/backend/src/main/java/backend/dto/ValidationResultResponse.java
+++ b/backend/src/main/java/backend/dto/ValidationResultResponse.java
@@ -18,6 +18,11 @@ public class ValidationResultResponse {
   private Map<
           @Min(value = 0, message = "Validation result row index minimum value is 0.")
           @Max(value = 6, message = "Validation result row index maximum value is 6.") Integer,
-          @NotNull(message = "Validation result must be true or false, not null.") Boolean>
+          Map<
+              @NotNull(
+                  message =
+                      "Validation result category (correctWord or duplicateWord) must not be null.")
+              String,
+              @NotNull(message = "Validation result must be true or false, not null.") Boolean>>
       validationResults;
 }

--- a/backend/src/main/java/backend/service/GameService.java
+++ b/backend/src/main/java/backend/service/GameService.java
@@ -7,7 +7,9 @@ import backend.dto.FixedLetterResponse;
 import backend.dto.GameGridRequest;
 import backend.dto.ValidationResultResponse;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -78,8 +80,24 @@ public class GameService {
   public ValidationResultResponse validateGameGrid(
       GameGridRequest gameGridRequest, Language language) {
     List<String> gameGridWords = utilityService.getGameGridWords(gameGridRequest);
-    ValidationResultResponse validationResultResponse =
-        repositoryService.validateWords(gameGridWords, language);
+    ValidationResultResponse validationResultResponse = new ValidationResultResponse();
+
+    // Check for correct words
+    Map<Integer, Boolean> correctWordMap = repositoryService.validateWords(gameGridWords, language);
+
+    // Check for duplicates
+    Map<String, Integer> wordCountMap = utilityService.countDuplicateWords(gameGridWords);
+
+    // Build response
+    Map<Integer, Map<String, Boolean>> validationResults = new HashMap<>();
+    for (int i = 0; i < gameGridWords.size(); i++) {
+      Map<String, Boolean> resultMap = new HashMap<>();
+      resultMap.put("correctWord", correctWordMap.get(i));
+      resultMap.put("duplicateWord", wordCountMap.get(gameGridWords.get(i)) > 1);
+      validationResults.put(i, resultMap);
+    }
+
+    validationResultResponse.setValidationResults(validationResults);
 
     return validationResultResponse;
   }

--- a/backend/src/main/java/backend/service/RepositoryService.java
+++ b/backend/src/main/java/backend/service/RepositoryService.java
@@ -2,11 +2,11 @@ package backend.service;
 
 import backend.domain.Language;
 import backend.domain.entities.Word;
-import backend.dto.ValidationResultResponse;
 import backend.repository.FinnishWordRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -64,9 +64,8 @@ public class RepositoryService {
     return wordCount;
   }
 
-  public ValidationResultResponse validateWords(List<String> gameGridWords, Language language) {
-    ValidationResultResponse validationResultResponse = new ValidationResultResponse();
-    HashMap<Integer, Boolean> resultsMap = new HashMap<>();
+  public Map<Integer, Boolean> validateWords(List<String> gameGridWords, Language language) {
+    Map<Integer, Boolean> resultsMap = new HashMap<>();
     Boolean result;
 
     switch (language) {
@@ -80,8 +79,8 @@ public class RepositoryService {
         throw new RuntimeException("Unknown language: " + language);
     }
 
-    validationResultResponse.setValidationResults(resultsMap);
+    System.out.println(resultsMap);
 
-    return validationResultResponse;
+    return resultsMap;
   }
 }

--- a/backend/src/main/java/backend/service/RepositoryService.java
+++ b/backend/src/main/java/backend/service/RepositoryService.java
@@ -79,8 +79,6 @@ public class RepositoryService {
         throw new RuntimeException("Unknown language: " + language);
     }
 
-    System.out.println(resultsMap);
-
     return resultsMap;
   }
 }

--- a/backend/src/main/java/backend/service/UtilityService.java
+++ b/backend/src/main/java/backend/service/UtilityService.java
@@ -2,7 +2,9 @@ package backend.service;
 
 import backend.dto.GameGridRequest;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.stereotype.Service;
 
@@ -60,5 +62,13 @@ public class UtilityService {
     }
 
     return gameGridWords;
+  }
+
+  public Map<String, Integer> countDuplicateWords(List<String> words) {
+    Map<String, Integer> wordCountMap = new HashMap<>();
+    for (String word : words) {
+      wordCountMap.put(word, wordCountMap.getOrDefault(word, 0) + 1);
+    }
+    return wordCountMap;
   }
 }

--- a/backend/src/test/java/backend/unit/GameServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/GameServiceUnitTests.java
@@ -18,7 +18,9 @@ import backend.service.GameService;
 import backend.service.RepositoryService;
 import backend.service.UtilityService;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -224,14 +226,30 @@ public class GameServiceUnitTests {
   public void validateGameGridShouldReturnValidationResultResponse() {
     GameGridRequest mockRequest = mock(GameGridRequest.class);
     ValidationResultResponse mockResponse = mock(ValidationResultResponse.class);
+    Map<Integer, Map<String, Boolean>> mockValidationResults = new HashMap<>();
+
+    for (int i = 0; i < 5; i++) {
+      Map<String, Boolean> resultMap = new HashMap<>();
+      resultMap.put("duplicateWord", false);
+      resultMap.put("correctWord", true);
+      mockValidationResults.put(i, resultMap);
+    }
+
+    when(mockResponse.getValidationResults()).thenReturn(mockValidationResults);
+
     List<String> mockWords = List.of("vehnä", "suola", "maito", "kahvi", "kerma");
+    Map<String, Integer> mockWordsCount =
+        Map.of("vehnä", 1, "suola", 1, "maito", 1, "kahvi", 1, "kerma", 1);
+
+    Map<Integer, Boolean> mockResultsMap = Map.of(0, true, 1, true, 2, true, 3, true, 4, true);
 
     when(mockUtilityService.getGameGridWords(mockRequest)).thenReturn(mockWords);
-    when(mockRepositoryService.validateWords(mockWords, language)).thenReturn(mockResponse);
+    when(mockUtilityService.countDuplicateWords(mockWords)).thenReturn(mockWordsCount);
+    when(mockRepositoryService.validateWords(mockWords, language)).thenReturn(mockResultsMap);
 
     ValidationResultResponse response = gameService.validateGameGrid(mockRequest, language);
 
-    assertEquals(mockResponse, response);
+    assertEquals(mockResponse.getValidationResults(), response.getValidationResults());
     verify(mockUtilityService).getGameGridWords(mockRequest);
     verify(mockRepositoryService).validateWords(mockWords, language);
   }

--- a/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/RepositoryServiceUnitTests.java
@@ -9,12 +9,13 @@ import static org.mockito.Mockito.when;
 import backend.domain.Language;
 import backend.domain.entities.FinnishWord;
 import backend.domain.entities.Word;
-import backend.dto.ValidationResultResponse;
 import backend.repository.FinnishWordRepository;
 import backend.service.RepositoryService;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -117,18 +118,24 @@ public class RepositoryServiceUnitTests {
   }
 
   @Test
-  public void validateWordsShouldReturnValidationResultResponse() {
-    List<String> testWords = Arrays.asList("vehnä", "maito");
-    when(mockFinnishWordRepository.validateWord("vehnä")).thenReturn(true);
-    when(mockFinnishWordRepository.validateWord("maito")).thenReturn(false);
+  void validateWordsReturnsCorrectMap() {
+    List<String> testWords = Arrays.asList("vehnä", "suola", "maito", "kahvi", "kerma");
+    Map<Integer, Boolean> mockResultsMap = new HashMap<>();
 
-    ValidationResultResponse response = repositoryService.validateWords(testWords, Language.FI);
+    for (int i = 0; i < testWords.size(); i++) {
+      mockResultsMap.put(i, true);
+    }
 
-    // Check that the response contains the expected validation results
-    assertEquals(true, response.getValidationResults().get(0));
-    assertEquals(false, response.getValidationResults().get(1));
-    verify(mockFinnishWordRepository).validateWord("vehnä");
-    verify(mockFinnishWordRepository).validateWord("maito");
+    for (String word : testWords) {
+      when(mockFinnishWordRepository.validateWord(word)).thenReturn(true);
+    }
+
+    Map<Integer, Boolean> result = repositoryService.validateWords(testWords, Language.FI);
+
+    assertEquals(mockResultsMap, result);
+    for (String word : testWords) {
+      verify(mockFinnishWordRepository).validateWord(word);
+    }
   }
 
   @Test

--- a/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
+++ b/backend/src/test/java/backend/unit/UtilityServiceUnitTests.java
@@ -8,6 +8,7 @@ import backend.dto.GameGridRequest;
 import backend.service.UtilityService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -138,5 +139,48 @@ public class UtilityServiceUnitTests {
                 Arrays.asList("K", "E", "R", "M", "")));
     assertThrows(
         IllegalArgumentException.class, () -> utilityService.getGameGridWords(testRequest));
+  }
+
+  @Test
+  public void countDuplicateWordsCountDuplicateWordsCorrectlyWhenNoDuplicatesArePresent() {
+    List<String> testWords = Arrays.asList("vehnä", "suola", "maito", "kahvi", "kerma");
+
+    Map<String, Integer> mockResultMap =
+        Map.of(
+            "vehnä", 1,
+            "suola", 1,
+            "maito", 1,
+            "kahvi", 1,
+            "kerma", 1);
+
+    Map<String, Integer> resultMap = utilityService.countDuplicateWords(testWords);
+
+    assertEquals(mockResultMap, resultMap);
+  }
+
+  @Test
+  public void countDuplicateWordsCountDuplicateWordsCorrectlyWhenOneDuplicateIsPresent() {
+    List<String> testWords = Arrays.asList("vehnä", "vehnä", "maito", "kahvi", "kerma");
+    Map<String, Integer> mockResultMap =
+        Map.of(
+            "vehnä", 2,
+            "maito", 1,
+            "kahvi", 1,
+            "kerma", 1);
+
+    Map<String, Integer> resultMap = utilityService.countDuplicateWords(testWords);
+
+    assertEquals(mockResultMap, resultMap);
+  }
+
+  @Test
+  public void countDuplicateWordsCountDuplicateWordsCorrectlyWhenAllWordsAreDuplicates() {
+    List<String> testWords = Arrays.asList("vehnä", "vehnä", "vehnä", "vehnä", "vehnä");
+
+    Map<String, Integer> mockResultMap = Map.of("vehnä", 5);
+
+    Map<String, Integer> resultMap = utilityService.countDuplicateWords(testWords);
+
+    assertEquals(mockResultMap, resultMap);
   }
 }

--- a/frontend/src/components/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/SanaboksiGameGrid.tsx
@@ -159,7 +159,12 @@ export default function SanaboksiGameGrid() {
               }
               isCorrect={
                 validationResults
-                  ? validationResults[rowIndex.toString()]
+                  ? validationResults[rowIndex.toString()]?.["correctWord"]
+                  : undefined
+              }
+              isDuplicate={
+                validationResults
+                  ? validationResults[rowIndex.toString()]?.["duplicateWord"]
                   : undefined
               }
             />

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import type { KeyboardEvent } from "react";
 import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../types/Types";
-import { IconCheck, IconX } from "@tabler/icons-react";
+import { IconCheck, IconX, IconCopyOff } from "@tabler/icons-react";
 
 /**
  * Props for the SanaboksiGameRow component.
@@ -20,6 +20,7 @@ interface SanaboksiGameRowProps {
   rowLength: number;
   onFieldChange?: (columnIndex: number, value: string) => void;
   isCorrect?: boolean;
+  isDuplicate?: boolean;
 }
 
 /**
@@ -34,6 +35,7 @@ export default function SanaboksiGameRow({
   rowLength,
   onFieldChange,
   isCorrect,
+  isDuplicate,
 }: SanaboksiGameRowProps) {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -102,13 +104,21 @@ export default function SanaboksiGameRow({
           fixedLetter && columnIndex === fixedLetter.fixedIndex;
         const cellValue = isPlaceholder ? "" : (rowData[columnIndex] ?? "");
         const correctBorderColor =
-          isCorrect === undefined ? "gray" : isCorrect ? "green" : "red";
+          isDuplicate === true
+            ? "blue"
+            : isCorrect === true
+              ? "green"
+              : isCorrect === false
+                ? "red"
+                : "gray";
 
         return (
           <TextInput
             key={columnIndex}
             value={cellValue}
-            readOnly={isPlaceholder || isFixedLetter || isCorrect}
+            readOnly={
+              isPlaceholder || isFixedLetter || (isCorrect && !isDuplicate)
+            }
             maxLength={1}
             w={50}
             ref={(el) => {
@@ -137,8 +147,15 @@ export default function SanaboksiGameRow({
           />
         );
       })}
-      {isCorrect !== undefined &&
-        (isCorrect ? <IconCheck color="green" /> : <IconX color="red" />)}
+      {isDuplicate === true ? (
+        <IconCopyOff color="blue" />
+      ) : isCorrect !== undefined ? (
+        isCorrect ? (
+          <IconCheck color="green" />
+        ) : (
+          <IconX color="red" />
+        )
+      ) : null}
     </Group>
   );
 }

--- a/frontend/src/components/SanaboksiGameRow.tsx
+++ b/frontend/src/components/SanaboksiGameRow.tsx
@@ -12,6 +12,7 @@ import { IconCheck, IconX, IconCopyOff } from "@tabler/icons-react";
  * @property rowLength The number of columns in the row.
  * @property onFieldChange Callback for when a field value changes.
  * @property isCorrect Whether the row is correct (true), incorrect (false), or not validated (undefined).
+ * @property isDuplicate Whether the row is a duplicate of another correct word (true), not a duplicate (false), or not validated (undefined).
  */
 interface SanaboksiGameRowProps {
   fixedLetter?: FixedLetter;

--- a/frontend/src/types/Types.tsx
+++ b/frontend/src/types/Types.tsx
@@ -17,4 +17,6 @@ export type GameGrid = string[][];
  * The key is the row index, and the value is whether the row is correct.
  * Example: { "0": true, "1": false }
  */
-export type ValidationResults = Record<string, boolean> | undefined;
+export type ValidationResults =
+  | Record<string, Record<string, boolean>>
+  | undefined;

--- a/frontend/src/types/Types.tsx
+++ b/frontend/src/types/Types.tsx
@@ -14,8 +14,8 @@ export type GameGrid = string[][];
 
 /**
  * Validation results for each row in the game grid.
- * The key is the row index, and the value is whether the row is correct.
- * Example: { "0": true, "1": false }
+ * The key is the row index, and the value is a map of validation categories to booleans.
+ * Example: { "0": { "correctWord": true, "duplicateWord": false } }
  */
 export type ValidationResults =
   | Record<string, Record<string, boolean>>

--- a/frontend/src/utility/UtilityFunctions.tsx
+++ b/frontend/src/utility/UtilityFunctions.tsx
@@ -41,7 +41,7 @@ const checkGameGridCorrectness = (validationResults: ValidationResults) => {
     return false;
   }
 
-  return rowCorrectness.every((value) => value === true);
+  return rowCorrectness.every((value) => value?.["correctWord"] === true);
 };
 
 export { checkGameGridValidity, checkGameGridCorrectness };

--- a/frontend/src/utility/UtilityFunctions.tsx
+++ b/frontend/src/utility/UtilityFunctions.tsx
@@ -41,7 +41,10 @@ const checkGameGridCorrectness = (validationResults: ValidationResults) => {
     return false;
   }
 
-  return rowCorrectness.every((value) => value?.["correctWord"] === true);
+  return rowCorrectness.every(
+    (value) =>
+      value?.["correctWord"] === true && value?.["duplicateWord"] === false,
+  );
 };
 
 export { checkGameGridValidity, checkGameGridCorrectness };


### PR DESCRIPTION
Closes #57 
This pull request introduces a more detailed validation system for the game grid, allowing the backend to return both "correct word" and "duplicate word" status for each row. The frontend and backend have been updated to support and display this richer validation information, and new tests have been added to ensure correctness.

**Backend: Enhanced Validation Response**

* The backend's `ValidationResultResponse` now returns a nested map for each row, indicating both whether the word is correct and whether it is a duplicate. The validation logic in `GameService` and `RepositoryService` has been refactored to support this, and a new utility method for counting duplicates has been added. [[1]](diffhunk://#diff-bd1a9f45fb640492ae4a1d91a13b5b8b9a85600a170d8d28a08403e7b7fff0cfL21-R26) [[2]](diffhunk://#diff-7897b03298291a1a650a3598090c7ab6202fb2057a7cf787cddaea92e64a2a6bL81-R100) [[3]](diffhunk://#diff-89c0166459a6fbd7257dada476b9d4396a472fbb9f89bfb05cac43d446ca608dR66-R73) [[4]](diffhunk://#diff-b1b7da461414f71975e343c4860d46bf9081ae1d0d8d6e5530fe551f8c946bdfL67-R68)

**Backend: API and Test Updates**

* The endpoint in `GameController` has been renamed to `validateGameGrid` for clarity, and unit tests for the new validation structure and duplicate detection have been added or updated across relevant test files. [[1]](diffhunk://#diff-a06fba69ad1ad861d009cade23b1771ace831be941e327f23d1ad076639a156dL34-R34) [[2]](diffhunk://#diff-9a13db00b02a243c179e27ef495a5abcf50f3b381df6f5c107cf5571af78df0dR229-R252) [[3]](diffhunk://#diff-37001d7f7bcee9f445b195930c0f129dc7f232a0e301377d06d929e9a50c913cL120-R138) [[4]](diffhunk://#diff-738f8e92094433d2f201911cf2aafdca5737bc70da3473510f0a98c8fb16467aR143-R185)

**Frontend: Support for Detailed Validation**

* The `ValidationResults` type now supports nested results for each row, and components have been updated to handle and display both "correct" and "duplicate" statuses. [[1]](diffhunk://#diff-51eddc2463ad995c1fcec38b73af73426bf53388fb267d7fcc4ff031991ab369L20-R22) [[2]](diffhunk://#diff-48bc7ef7b01ffc541f94e3afaecb236c7922b4edad9b1b5049a76e82ac2f71baL162-R167)

**Frontend: UI Enhancements for Duplicate Detection**

* `SanaboksiGameRow` now receives an `isDuplicate` prop and displays a blue border and icon if a row is a duplicate, updating the visual feedback logic and read-only state accordingly. [[1]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aR23) [[2]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aL105-R121) [[3]](diffhunk://#diff-51c48eaf93769192603e50a5b25588908ed9db08775625c25670098d47434a0aL140-R158)

**Frontend: Utility Function Updates**

* The utility function for checking game grid correctness now checks only the "correctWord" status for each row.