### PR TITLE
Chore/Fix pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Get all staged files
-STAGED_BACKEND_FILES=$(git diff --cached --name-only | grep "^backend/.*\.java$" || true)
-STAGED_FRONTEND_FILES=$(git diff --cached --name-only | grep -E "^frontend/.*\.(js|ts|jsx|tsx|html|css)$" || true)
+STAGED_BACKEND_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^backend/.*\.java$" || true)
+STAGED_FRONTEND_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E "^frontend/.*\.(js|ts|jsx|tsx|html|css)$" || true)
 
 # Format backend files (if exist)
 if [[ -n "$STAGED_BACKEND_FILES" ]]; then


### PR DESCRIPTION
Fix pre-commit-hook to only apply formatting and linting to added, copied or modified files