### PR TITLE
Issue/#44 Add game instructions

### DIFF
--- a/frontend/src/components/game/SanaboksiGameRow.tsx
+++ b/frontend/src/components/game/SanaboksiGameRow.tsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import type { KeyboardEvent } from "react";
 import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../../types/Types";
-import { IconCheck, IconX, IconCopyOff } from "@tabler/icons-react";
+import { IconCheck, IconX, IconCopy } from "@tabler/icons-react";
 import { useColorPalette } from "../../hooks/useColorPalette";
 
 /**
@@ -15,6 +15,7 @@ import { useColorPalette } from "../../hooks/useColorPalette";
  * @property onFieldChange Callback for when a field value changes.
  * @property isCorrect Whether the row is correct (true), incorrect (false), or not validated (undefined).
  * @property isDuplicate Whether the row is a duplicate of another correct word (true), not a duplicate (false), or not validated (undefined).
+ * @property isDuplicate Whether the row has read only value.
  */
 interface SanaboksiGameRowProps {
   fixedLetter?: FixedLetter;
@@ -25,6 +26,7 @@ interface SanaboksiGameRowProps {
   onFieldChange?: (columnIndex: number, value: string) => void;
   isCorrect?: boolean;
   isDuplicate?: boolean;
+  isReadOnly?: boolean;
 }
 
 /**
@@ -41,6 +43,7 @@ export default function SanaboksiGameRow({
   onFieldChange,
   isCorrect,
   isDuplicate,
+  isReadOnly,
 }: SanaboksiGameRowProps) {
   const colorPalette = useColorPalette();
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -129,7 +132,10 @@ export default function SanaboksiGameRow({
             key={columnIndex}
             value={cellValue}
             readOnly={
-              isPlaceholder || isFixedLetter || (isCorrect && !isDuplicate)
+              isPlaceholder ||
+              isFixedLetter ||
+              (isCorrect && !isDuplicate) ||
+              isReadOnly
             }
             maxLength={1}
             ref={(el) => {
@@ -166,7 +172,7 @@ export default function SanaboksiGameRow({
       })}
 
       {isDuplicate === true ? (
-        <IconCopyOff
+        <IconCopy
           aria-label="Duplicate word icon"
           color={colorPalette[5]}
           size={iconSize}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,6 +7,8 @@ import {
 } from "@mantine/core";
 import { IconSunMoon, IconInfoCircle } from "@tabler/icons-react";
 import { useColorPalette } from "../../hooks/useColorPalette";
+import { GameInstructionsModal } from "../modals/GameInstructionsModal";
+import { useDisclosure } from "@mantine/hooks";
 
 export default function Header() {
   const colorPalette = useColorPalette();
@@ -17,6 +19,7 @@ export default function Header() {
     iconSize: "clamp(20px, 6vw, 35px)",
     iconStrokeWidth: 2,
   };
+  const [opened, { open, close }] = useDisclosure(false);
 
   return (
     <Container
@@ -31,6 +34,7 @@ export default function Header() {
           <ActionIcon
             variant="subtle"
             size={iconSize}
+            onClick={() => open()}
             styles={{
               root: {
                 backgroundColor: colorPalette[0],
@@ -67,6 +71,7 @@ export default function Header() {
           </ActionIcon>
         </Grid.Col>
       </Grid>
+      <GameInstructionsModal opened={opened} onClose={close} />
     </Container>
   );
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -9,9 +9,11 @@ import { IconSunMoon, IconInfoCircle } from "@tabler/icons-react";
 import { useColorPalette } from "../../hooks/useColorPalette";
 import { GameInstructionsModal } from "../modals/GameInstructionsModal";
 import { useDisclosure } from "@mantine/hooks";
+import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const colorPalette = useColorPalette();
+  const { t } = useTranslation();
   const { toggleColorScheme } = useMantineColorScheme();
   const { headerMargin, headerGutter, iconSize, iconStrokeWidth } = {
     headerMargin: 20,
@@ -32,6 +34,7 @@ export default function Header() {
           style={{ display: "flex", justifyContent: "flex-start" }}
         >
           <ActionIcon
+            aria-label={t("AriaLabel.OpenGameInstructions")}
             variant="subtle"
             size={iconSize}
             onClick={() => open()}

--- a/frontend/src/components/modals/GameInstructionsModal.tsx
+++ b/frontend/src/components/modals/GameInstructionsModal.tsx
@@ -1,0 +1,182 @@
+import { Divider, Group, Modal, Stack, Text } from "@mantine/core";
+import { useColorPalette } from "../../hooks/useColorPalette";
+import { IconCheck, IconX, IconCopy } from "@tabler/icons-react";
+import SanaboksiGameRow from "../game/SanaboksiGameRow";
+import type { FixedLetter } from "../../types/Types";
+import { useTranslation } from "react-i18next";
+
+interface GameInstructionsModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+export function GameInstructionsModal({
+  opened,
+  onClose,
+}: GameInstructionsModalProps) {
+  const colorPalette = useColorPalette();
+  const { t } = useTranslation();
+  const {
+    iconSize,
+    iconStrokeWidth,
+    textMarginTop,
+    textMarginBottom,
+    iconMarginTop,
+    iconMarginBottom,
+  } = {
+    iconSize: 30,
+    iconStrokeWidth: 2,
+    textMarginTop: 10,
+    textMarginBottom: 10,
+    iconMarginTop: 5,
+    iconMarginBottom: 15,
+  };
+  const fixedLetter: FixedLetter = { fixedIndex: 2, fixedLetter: "H" };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      size="lg"
+      title={t("GameInstructionModal.HowToPlaySanaboksi")}
+      styles={{
+        header: { backgroundColor: colorPalette[0], color: colorPalette[2] },
+        body: {
+          backgroundColor: colorPalette[0],
+          color: colorPalette[2],
+        },
+        title: { fontSize: 24 },
+      }}
+    >
+      <Text styles={{ root: { marginTop: textMarginTop } }}>
+        {t("GameInstructionModal.GameDescription")}
+      </Text>
+
+      <Text
+        styles={{
+          root: { marginTop: textMarginTop, marginBottom: textMarginBottom },
+        }}
+      >
+        {t("GameInstructionModal.ForExampleIfGivenRowIs")}
+      </Text>
+
+      <SanaboksiGameRow
+        fixedLetter={fixedLetter}
+        rowIndex={0}
+        rowLength={5}
+        isReadOnly={true}
+        rowData={["", "", "H", "", ""]}
+      ></SanaboksiGameRow>
+
+      <Text
+        styles={{
+          root: { marginTop: textMarginTop, marginBottom: textMarginBottom },
+        }}
+      >
+        {t("GameInstructionModal.FittingWordsCouldBe")}
+      </Text>
+
+      <SanaboksiGameRow
+        fixedLetter={fixedLetter}
+        rowIndex={0}
+        rowLength={5}
+        isReadOnly={true}
+        rowData={["V", "E", "H", "N", "Ä"]}
+      ></SanaboksiGameRow>
+
+      <Text
+        styles={{
+          root: { marginTop: textMarginTop, marginBottom: textMarginBottom },
+        }}
+      >
+        {t("GameInstructionModal.And")}
+      </Text>
+
+      <SanaboksiGameRow
+        fixedLetter={fixedLetter}
+        rowIndex={0}
+        rowLength={5}
+        isReadOnly={true}
+        rowData={["K", "A", "H", "V", "I"]}
+      ></SanaboksiGameRow>
+
+      <Text styles={{ root: { marginTop: textMarginTop } }}>
+        {t(
+          "GameInstructionModal.BecauseFixedLetterIsInTheCorrectPositionInBothWords",
+        )}
+      </Text>
+
+      <Text styles={{ root: { marginTop: textMarginTop } }}>
+        {t("GameInstructionModal.GamePlayInstructions")}
+      </Text>
+
+      <Text styles={{ root: { marginTop: textMarginTop } }}>
+        {t("GameInstructionModal.AfterValidationInstructions")}
+      </Text>
+
+      <Text
+        styles={{
+          root: { marginTop: textMarginTop, marginBottom: textMarginBottom },
+        }}
+      >
+        {t(
+          "GameInstructionModal.OnceYouFillInTheGridWithCorrectWordsYouCanPlayANewGame",
+        )}
+      </Text>
+
+      <Divider color={colorPalette[2]} />
+
+      <Text styles={{ root: { marginTop: textMarginTop } }}>
+        {t("GameInstructionModal.BeMindfulOfTheseIconsAndColors")}:
+      </Text>
+
+      <Stack>
+        <Group
+          align="center"
+          gap="sm"
+          styles={{ root: { marginTop: iconMarginTop } }}
+        >
+          <IconCheck
+            aria-label="Correct word icon"
+            color={colorPalette[4]}
+            size={iconSize}
+            strokeWidth={2}
+          />
+          <Text>{t("GameInstructionModal.TheWordIsCorrect")}</Text>
+        </Group>
+        <Group
+          align="center"
+          gap="sm"
+          styles={{ root: { marginTop: iconMarginTop } }}
+        >
+          <IconX
+            aria-label="Incorrect word icon"
+            color={colorPalette[6]}
+            size={iconSize}
+            strokeWidth={iconStrokeWidth}
+          />
+          <Text>{t("GameInstructionModal.TheWordIsIncorrect")}</Text>
+        </Group>
+        <Group
+          align="center"
+          gap="sm"
+          styles={{
+            root: { marginTop: iconMarginTop, marginBottom: iconMarginBottom },
+          }}
+        >
+          <IconCopy
+            aria-label="Duplicate word icon"
+            color={colorPalette[5]}
+            size={iconSize}
+            strokeWidth={iconStrokeWidth}
+          />
+          <Text>{t("GameInstructionModal.TheWordIsADuplicate")}</Text>
+        </Group>
+      </Stack>
+      <Divider color={colorPalette[2]} />
+      <Text styles={{ root: { marginTop: textMarginTop + 5 } }}>
+        {t("GameInstructionModal.HaveFunWithSanaboksi")}
+      </Text>
+    </Modal>
+  );
+}

--- a/frontend/src/components/modals/GameInstructionsModal.tsx
+++ b/frontend/src/components/modals/GameInstructionsModal.tsx
@@ -137,7 +137,7 @@ export function GameInstructionsModal({
           styles={{ root: { marginTop: iconMarginTop } }}
         >
           <IconCheck
-            aria-label="Correct word icon"
+            aria-label={t("AriaLabel.CorrectWordIcon")}
             color={colorPalette[4]}
             size={iconSize}
             strokeWidth={2}
@@ -150,7 +150,7 @@ export function GameInstructionsModal({
           styles={{ root: { marginTop: iconMarginTop } }}
         >
           <IconX
-            aria-label="Incorrect word icon"
+            aria-label={t("AriaLabel.IncorrectWordIcon")}
             color={colorPalette[6]}
             size={iconSize}
             strokeWidth={iconStrokeWidth}
@@ -165,7 +165,7 @@ export function GameInstructionsModal({
           }}
         >
           <IconCopy
-            aria-label="Duplicate word icon"
+            aria-label={t("AriaLabel.DuplicateWordIcon")}
             color={colorPalette[5]}
             size={iconSize}
             strokeWidth={iconStrokeWidth}

--- a/frontend/src/config/locales/fi/fiTranslations.json
+++ b/frontend/src/config/locales/fi/fiTranslations.json
@@ -28,5 +28,21 @@
       "UnknownErrorHasOccurred": "Tapahtui odottamaton virhe.",
       "NoItWasNotYouReportBug": "Ei, se ei johtunut sinusta. Täytäthän bugi-ilmoituksen, jotta asia voidaan korjata. Kiitos!"
     }
+  },
+  "GameInstructionModal": {
+    "HowToPlaySanaboksi": "Kuinka pelata Sanaboksia",
+    "GameDescription": "Sanaboksi on peli, jossa tehtävänäsi on keksiä ruudukon joka riville sana, johon rivillä jo annettu kirjain sopii.",
+    "ForExampleIfGivenRowIs": "Esimerkiksi jos annettu rivi on",
+    "FittingWordsCouldBe": "sopisi siihen sanat",
+    "And": "ja",
+    "BecauseFixedLetterIsInTheCorrectPositionInBothWords": "koska annettu kirjain H on kummassakin sanassa oikeassa paikassa.",
+    "GamePlayInstructions": "Tarkistaaksesi sanat sinun täytyy täyttää kaikki rivit. Sanat tulee täyttää ruudukkoon perusmuodossa. Ruudukossa ei saa esiintyä sanoja useammin kuin kerran.",
+    "AfterValidationInstructions": "Tarkistuksen jälkeen peli kertoo sinulle, mitkä sanat olivat oikein, mitkä olivat väärin tai mitkä sanat esiintyivät ruudukossa useammin kuin kerran. Voit korjata sanoja kunnes saat kaikki sanat oikein.",
+    "OnceYouFillInTheGridWithCorrectWordsYouCanPlayANewGame": "Täytettyäsi ruudukon hyväksytyillä sanoilla voit pelata uuden pelin.",
+    "BeMindfulOfTheseIconsAndColors": "Tarkkaile näitä merkkejä ja värejä",
+    "TheWordIsCorrect": "Sana on oikein (eli sana on oikea suomen kielen sana)",
+    "TheWordIsIncorrect": "Sana on väärin (eli sanaa ei löydy suomen kielen sanastosta)",
+    "TheWordIsADuplicate": "Sana esiintyy ruudukossa useammin kuin kerran",
+    "HaveFunWithSanaboksi": "Hauskoja pelihetkiä Sanaboksin parissa!"
   }
 }

--- a/frontend/src/config/locales/fi/fiTranslations.json
+++ b/frontend/src/config/locales/fi/fiTranslations.json
@@ -44,5 +44,11 @@
     "TheWordIsIncorrect": "Sana on väärin (eli sanaa ei löydy suomen kielen sanastosta)",
     "TheWordIsADuplicate": "Sana esiintyy ruudukossa useammin kuin kerran",
     "HaveFunWithSanaboksi": "Hauskoja pelihetkiä Sanaboksin parissa!"
+  },
+  "AriaLabel": {
+    "OpenGameInstructions": "Avaa peliohjeet",
+    "CorrectWordIcon": "Oikean sanan merkki",
+    "IncorrectWordIcon": "Väärän sanan merkki",
+    "DuplicateWordIcon": "Toistuvan sanan merkki"
   }
 }

--- a/frontend/tests/icon-button-tests.spec.ts
+++ b/frontend/tests/icon-button-tests.spec.ts
@@ -19,3 +19,11 @@ test("Toggles light/dark mode when dark/light mode icon is clicked", async ({
 
   expect(newMode).not.toBe(initialMode);
 });
+
+test("Clicking info button opens game instruction modal", async ({ page }) => {
+  await page.getByRole("button", { name: "Avaa peliohjeet" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Kuinka pelata Sanaboksia" }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
Closes #44 
This pull request introduces a new modal with game instructions for the Sanaboksi game, improves accessibility and localization, and updates icon usage for clarity. The most significant changes are the addition of the instructions modal, updates to the `SanaboksiGameRow` component to support read-only mode, and the inclusion of new localization strings and tests.

**Game Instructions Modal:**

* Added a new `GameInstructionsModal` component that provides users with detailed instructions on how to play Sanaboksi, including visual examples and icon explanations. The modal supports localization and uses the existing color palette and iconography. (`frontend/src/components/modals/GameInstructionsModal.tsx`)
* Integrated the modal into the `Header` component, allowing users to open it via an info icon button. The button and modal use localized aria-labels and text for accessibility. (`frontend/src/components/layout/Header.tsx`) [[1]](diffhunk://#diff-40340c6f9220694b29ec69af6d61d68783d5eb9a29dd2ff7327589131213f588R10-R24) [[2]](diffhunk://#diff-40340c6f9220694b29ec69af6d61d68783d5eb9a29dd2ff7327589131213f588R37-R40) [[3]](diffhunk://#diff-40340c6f9220694b29ec69af6d61d68783d5eb9a29dd2ff7327589131213f588R77)

**SanaboksiGameRow Enhancements:**

* Added an `isReadOnly` prop to the `SanaboksiGameRow` component, allowing rows to be rendered as non-editable (used for examples in the instructions modal). Updated the logic to respect this prop. (`frontend/src/components/game/SanaboksiGameRow.tsx`) [[1]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901R18) [[2]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901R29) [[3]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901R46) [[4]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L132-R138)
* Updated the duplicate word icon from `IconCopyOff` to `IconCopy` for consistency and clarity. (`frontend/src/components/game/SanaboksiGameRow.tsx`) [[1]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L5-R5) [[2]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L169-R175)

**Localization and Accessibility:**

* Added new translation strings for the game instructions modal and related aria-labels in the Finnish locale file. (`frontend/src/config/locales/fi/fiTranslations.json`)

**Testing:**

* Added an end-to-end test to verify that clicking the info button opens the game instructions modal and displays the correct heading. (`frontend/tests/icon-button-tests.spec.ts`)