### PR TITLE
Issue/#83 Translate aria-labels

### DIFF
--- a/frontend/src/components/game/SanaboksiGameGrid.tsx
+++ b/frontend/src/components/game/SanaboksiGameGrid.tsx
@@ -192,7 +192,7 @@ export default function SanaboksiGameGrid() {
 
   return (
     <>
-      <Container strategy="grid" aria-label="Sanaboksi game grid">
+      <Container strategy="grid" aria-label={t("AriaLabel.SanaBoksiGameGrid")}>
         <Stack gap={9}>
           {fixedLetters.length === 0
             ? // Render empty game grid rows

--- a/frontend/src/components/game/SanaboksiGameRow.tsx
+++ b/frontend/src/components/game/SanaboksiGameRow.tsx
@@ -4,6 +4,7 @@ import { TextInput, Group } from "@mantine/core";
 import type { FixedLetter } from "../../types/Types";
 import { IconCheck, IconX, IconCopy } from "@tabler/icons-react";
 import { useColorPalette } from "../../hooks/useColorPalette";
+import { useTranslation } from "react-i18next";
 
 /**
  * Props for the SanaboksiGameRow component.
@@ -46,6 +47,7 @@ export default function SanaboksiGameRow({
   isReadOnly,
 }: SanaboksiGameRowProps) {
   const colorPalette = useColorPalette();
+  const { t } = useTranslation();
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
   const { iconSize, iconStrokeWidth, iconMargin } = {
     iconSize: "clamp(25px, 12vw, 35px)",
@@ -112,7 +114,11 @@ export default function SanaboksiGameRow({
   };
 
   return (
-    <Group gap={3} align="center" aria-label={`Word ${rowIndex + 1}`}>
+    <Group
+      gap={3}
+      align="center"
+      aria-label={`${t("AriaLabel.Word")} ${rowIndex + 1}`}
+    >
       {Array.from({ length: rowLength }).map((_, columnIndex) => {
         const isFixedLetter =
           fixedLetter && columnIndex === fixedLetter.fixedIndex;
@@ -128,7 +134,7 @@ export default function SanaboksiGameRow({
 
         return (
           <TextInput
-            aria-label={`Word ${rowIndex + 1}, letter ${columnIndex + 1}`}
+            aria-label={`${t("AriaLabel.Word")} ${rowIndex + 1}, ${t("AriaLabel.Letter")} ${columnIndex + 1}`}
             key={columnIndex}
             value={cellValue}
             readOnly={
@@ -173,7 +179,7 @@ export default function SanaboksiGameRow({
 
       {isDuplicate === true ? (
         <IconCopy
-          aria-label="Duplicate word icon"
+          aria-label={t("AriaLabel.DuplicateWordIcon")}
           color={colorPalette[5]}
           size={iconSize}
           strokeWidth={iconStrokeWidth}
@@ -182,7 +188,7 @@ export default function SanaboksiGameRow({
       ) : isCorrect !== undefined ? (
         isCorrect ? (
           <IconCheck
-            aria-label="Correct word icon"
+            aria-label={t("AriaLabel.CorrectWordIcon")}
             color={colorPalette[4]}
             size={iconSize}
             strokeWidth={2}
@@ -190,7 +196,7 @@ export default function SanaboksiGameRow({
           />
         ) : (
           <IconX
-            aria-label="Incorrect word icon"
+            aria-label={t("AriaLabel.IncorrectWordIcon")}
             color={colorPalette[6]}
             size={iconSize}
             strokeWidth={iconStrokeWidth}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
           style={{ display: "flex", justifyContent: "flex-end" }}
         >
           <ActionIcon
-            aria-label="Toggle light/dark mode"
+            aria-label={t("AriaLabel.ToggleLightDarkMode")}
             variant="subtle"
             size={iconSize}
             onClick={() => toggleColorScheme()}

--- a/frontend/src/config/locales/fi/fiTranslations.json
+++ b/frontend/src/config/locales/fi/fiTranslations.json
@@ -46,9 +46,13 @@
     "HaveFunWithSanaboksi": "Hauskoja pelihetkiä Sanaboksin parissa!"
   },
   "AriaLabel": {
-    "OpenGameInstructions": "Avaa peliohjeet",
+    "SanaboksiGameGrid": "Sanaboksi-ruudukko",
+    "Word": "Sana",
+    "Letter": "Kirjain",
     "CorrectWordIcon": "Oikean sanan merkki",
     "IncorrectWordIcon": "Väärän sanan merkki",
-    "DuplicateWordIcon": "Toistuvan sanan merkki"
+    "DuplicateWordIcon": "Toistuvan sanan merkki",
+    "OpenGameInstructions": "Avaa peliohjeet",
+    "ToggleLightDarkMode": "Vaihda vaalea/tumma tila"
   }
 }

--- a/frontend/src/config/locales/fi/fiTranslations.json
+++ b/frontend/src/config/locales/fi/fiTranslations.json
@@ -6,7 +6,7 @@
   "NotificationModal": {
     "Invalid": {
       "GameGridHasEmptyFields": "Ruudukossa on tyhjiä ruutuja!",
-      "FillInAllEmptyFields": "Täytä kaikki ryhjät ruudut."
+      "FillInAllEmptyFields": "Täytä kaikki tyhjät ruudut."
     },
     "IncorrectAnDuplicate": {
       "GameGridHasIncorrectAndDuplicateWords": "Ruudukossa on sekä vääriä sanoja että useampi sama sana!",

--- a/frontend/tests/game-grid-tests.spec.ts
+++ b/frontend/tests/game-grid-tests.spec.ts
@@ -22,30 +22,30 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("Game grid loads fixed letters on page load", async ({ page }) => {
-  const word1Letter = page.getByRole("textbox", { name: "Word 1, letter 1" });
+  const word1Letter = page.getByRole("textbox", { name: "Sana 1, Kirjain 1" });
   await expect(word1Letter).toHaveValue("V");
 
-  const word2Letter = page.getByRole("textbox", { name: "Word 2, letter 2" });
+  const word2Letter = page.getByRole("textbox", { name: "Sana 2, Kirjain 2" });
   await expect(word2Letter).toHaveValue("U");
 
-  const word3Letter = page.getByRole("textbox", { name: "Word 3, letter 3" });
+  const word3Letter = page.getByRole("textbox", { name: "Sana 3, Kirjain 3" });
   await expect(word3Letter).toHaveValue("I");
 
-  const word4Letter = page.getByRole("textbox", { name: "Word 4, letter 4" });
+  const word4Letter = page.getByRole("textbox", { name: "Sana 4, Kirjain 4" });
   await expect(word4Letter).toHaveValue("V");
 
-  const word5Letter = page.getByRole("textbox", { name: "Word 5, letter 5" });
+  const word5Letter = page.getByRole("textbox", { name: "Sana 5, Kirjain 5" });
   await expect(word5Letter).toHaveValue("A");
 });
 
 test("Player can input letters into the game grid", async ({ page }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
   const letters = await page
-    .getByRole("textbox", { name: "Word 1" })
+    .getByRole("textbox", { name: "Sana 1" })
     .evaluateAll((inputs) =>
       inputs.map((input) => (input as HTMLInputElement).value),
     );
@@ -56,30 +56,30 @@ test("Player can input letters into the game grid", async ({ page }) => {
 test("Player can validate a game grid when all words are correct", async ({
   page,
 }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
-  await page.getByRole("textbox", { name: "Word 2, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 2, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 2, letter 4" }).fill("L");
-  await page.getByRole("textbox", { name: "Word 2, letter 5" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 5" }).fill("A");
 
-  await page.getByRole("textbox", { name: "Word 3, letter 1" }).fill("M");
-  await page.getByRole("textbox", { name: "Word 3, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 3, letter 4" }).fill("T");
-  await page.getByRole("textbox", { name: "Word 3, letter 5" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 1" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 4" }).fill("T");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 5" }).fill("O");
 
-  await page.getByRole("textbox", { name: "Word 4, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 4, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 4, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 4, letter 5" }).fill("I");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 5" }).fill("I");
 
-  await page.getByRole("textbox", { name: "Word 5, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 5, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 5, letter 3" }).fill("R");
-  await page.getByRole("textbox", { name: "Word 5, letter 4" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 3" }).fill("R");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 4" }).fill("M");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -91,10 +91,10 @@ test("Player can validate a game grid when all words are correct", async ({
 });
 
 test("Player cannot validate an incomplete game grid", async ({ page }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -106,30 +106,30 @@ test("Player cannot validate an incomplete game grid", async ({ page }) => {
 test("Player cannot validate a game grid with duplicate words", async ({
   page,
 }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
-  await page.getByRole("textbox", { name: "Word 2, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 2, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 2, letter 4" }).fill("L");
-  await page.getByRole("textbox", { name: "Word 2, letter 5" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 5" }).fill("A");
 
-  await page.getByRole("textbox", { name: "Word 3, letter 1" }).fill("M");
-  await page.getByRole("textbox", { name: "Word 3, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 3, letter 4" }).fill("T");
-  await page.getByRole("textbox", { name: "Word 3, letter 5" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 1" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 4" }).fill("T");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 5" }).fill("O");
 
-  await page.getByRole("textbox", { name: "Word 4, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 4, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 4, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 4, letter 5" }).fill("I");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 5" }).fill("I");
 
-  await page.getByRole("textbox", { name: "Word 5, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 5, letter 2" }).fill("U");
-  await page.getByRole("textbox", { name: "Word 5, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 5, letter 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 2" }).fill("U");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 4" }).fill("L");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -141,30 +141,30 @@ test("Player cannot validate a game grid with duplicate words", async ({
 test("Player cannot validate a game grid with incorrect words", async ({
   page,
 }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
-  await page.getByRole("textbox", { name: "Word 2, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 2, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 2, letter 4" }).fill("L");
-  await page.getByRole("textbox", { name: "Word 2, letter 5" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 5" }).fill("A");
 
-  await page.getByRole("textbox", { name: "Word 3, letter 1" }).fill("M");
-  await page.getByRole("textbox", { name: "Word 3, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 3, letter 4" }).fill("T");
-  await page.getByRole("textbox", { name: "Word 3, letter 5" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 1" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 4" }).fill("T");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 5" }).fill("O");
 
-  await page.getByRole("textbox", { name: "Word 4, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 4, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 4, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 4, letter 5" }).fill("I");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 5" }).fill("I");
 
-  await page.getByRole("textbox", { name: "Word 5, letter 1" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 5, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 5, letter 3" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 5, letter 4" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 1" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 3" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 4" }).fill("A");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -176,30 +176,30 @@ test("Player cannot validate a game grid with incorrect words", async ({
 test("Player cannot validate a game grid with duplicate and incorrect words", async ({
   page,
 }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
-  await page.getByRole("textbox", { name: "Word 2, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 2, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 2, letter 4" }).fill("L");
-  await page.getByRole("textbox", { name: "Word 2, letter 5" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 5" }).fill("A");
 
-  await page.getByRole("textbox", { name: "Word 3, letter 1" }).fill("M");
-  await page.getByRole("textbox", { name: "Word 3, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 3, letter 4" }).fill("T");
-  await page.getByRole("textbox", { name: "Word 3, letter 5" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 1" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 4" }).fill("T");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 5" }).fill("O");
 
-  await page.getByRole("textbox", { name: "Word 4, letter 1" }).fill("V");
-  await page.getByRole("textbox", { name: "Word 4, letter 2" }).fill("V");
-  await page.getByRole("textbox", { name: "Word 4, letter 3" }).fill("V");
-  await page.getByRole("textbox", { name: "Word 4, letter 5" }).fill("V");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 1" }).fill("V");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 2" }).fill("V");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 3" }).fill("V");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 5" }).fill("V");
 
-  await page.getByRole("textbox", { name: "Word 5, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 5, letter 2" }).fill("U");
-  await page.getByRole("textbox", { name: "Word 5, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 5, letter 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 2" }).fill("U");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 4" }).fill("L");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -213,30 +213,30 @@ test("Player cannot validate a game grid with duplicate and incorrect words", as
 test("Player can play another game after validating a correct game grid", async ({
   page,
 }) => {
-  await page.getByRole("textbox", { name: "Word 1, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 1, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 1, letter 4" }).fill("N");
-  await page.getByRole("textbox", { name: "Word 1, letter 5" }).fill("Ä");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 4" }).fill("N");
+  await page.getByRole("textbox", { name: "Sana 1, Kirjain 5" }).fill("Ä");
 
-  await page.getByRole("textbox", { name: "Word 2, letter 1" }).fill("S");
-  await page.getByRole("textbox", { name: "Word 2, letter 3" }).fill("O");
-  await page.getByRole("textbox", { name: "Word 2, letter 4" }).fill("L");
-  await page.getByRole("textbox", { name: "Word 2, letter 5" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 1" }).fill("S");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 3" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 4" }).fill("L");
+  await page.getByRole("textbox", { name: "Sana 2, Kirjain 5" }).fill("A");
 
-  await page.getByRole("textbox", { name: "Word 3, letter 1" }).fill("M");
-  await page.getByRole("textbox", { name: "Word 3, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 3, letter 4" }).fill("T");
-  await page.getByRole("textbox", { name: "Word 3, letter 5" }).fill("O");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 1" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 4" }).fill("T");
+  await page.getByRole("textbox", { name: "Sana 3, Kirjain 5" }).fill("O");
 
-  await page.getByRole("textbox", { name: "Word 4, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 4, letter 2" }).fill("A");
-  await page.getByRole("textbox", { name: "Word 4, letter 3" }).fill("H");
-  await page.getByRole("textbox", { name: "Word 4, letter 5" }).fill("I");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 2" }).fill("A");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 3" }).fill("H");
+  await page.getByRole("textbox", { name: "Sana 4, Kirjain 5" }).fill("I");
 
-  await page.getByRole("textbox", { name: "Word 5, letter 1" }).fill("K");
-  await page.getByRole("textbox", { name: "Word 5, letter 2" }).fill("E");
-  await page.getByRole("textbox", { name: "Word 5, letter 3" }).fill("R");
-  await page.getByRole("textbox", { name: "Word 5, letter 4" }).fill("M");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 1" }).fill("K");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 2" }).fill("E");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 3" }).fill("R");
+  await page.getByRole("textbox", { name: "Sana 5, Kirjain 4" }).fill("M");
 
   await page.getByRole("button", { name: "Tarkista sanat" }).click();
 
@@ -258,7 +258,7 @@ test("Player can play another game after validating a correct game grid", async 
   ).toBeVisible();
 
   const letters = await page
-    .getByRole("textbox", { name: "Word 1" })
+    .getByRole("textbox", { name: "Sana 1" })
     .evaluateAll((inputs) =>
       inputs.map((input) => (input as HTMLInputElement).value),
     );

--- a/frontend/tests/icon-button-tests.spec.ts
+++ b/frontend/tests/icon-button-tests.spec.ts
@@ -11,7 +11,7 @@ test("Toggles light/dark mode when dark/light mode icon is clicked", async ({
     .locator("html")
     .getAttribute("data-mantine-color-scheme");
 
-  await page.getByRole("button", { name: "Toggle light/dark mode" }).click();
+  await page.getByRole("button", { name: "Vaihda vaalea/tumma tila" }).click();
 
   const newMode = await page
     .locator("html")


### PR DESCRIPTION
Closes #83 
This pull request improves accessibility and localization in the Sanaboksi game by making all ARIA labels translatable and updating the Finnish translation files accordingly. It also updates tests to match the new localized ARIA labels, ensuring consistency and better support for non-English users.

**Accessibility and Localization Improvements:**

* All ARIA labels in game components (`SanaboksiGameGrid`, `SanaboksiGameRow`, and header) are now sourced from translation files using the `t` function, making them fully translatable for different languages. This includes dynamic ARIA labels for grid, rows, textboxes, and icons. [[1]](diffhunk://#diff-99ff3b7d3665f49a63e27b5e36d6fe8674ab0a86a2e3d7d6338af645d9c3161bL195-R195) [[2]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901R50) [[3]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L115-R121) [[4]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L131-R137) [[5]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L176-R182) [[6]](diffhunk://#diff-d71d72f684b483d9f48af23d3a4cf103014053ac326012faa2f4c91ed4c4a901L185-R199) [[7]](diffhunk://#diff-40340c6f9220694b29ec69af6d61d68783d5eb9a29dd2ff7327589131213f588L62-R62)

* The Finnish translations (`fiTranslations.json`) are expanded to include new ARIA label keys and fix a typo in an existing notification message. [[1]](diffhunk://#diff-5e3598e409cb06136ae7fb06d027747db0565d901fd923106dbb356a0e8c2af2L9-R9) [[2]](diffhunk://#diff-5e3598e409cb06136ae7fb06d027747db0565d901fd923106dbb356a0e8c2af2L49-R56)

**Testing Updates:**

* All Playwright tests for the game grid are updated to use the new, localized ARIA labels (e.g., "Sana 1, Kirjain 2" instead of "Word 1, letter 2"), ensuring tests remain valid and reflect the improved accessibility and localization. [[1]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL25-R48) [[2]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL59-R82) [[3]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL94-R97) [[4]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL109-R132) [[5]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL144-R167) [[6]](diffhunk://#diff-dbd12353bf65bf759045d0bf90968aebedd9633d67e4c2bc3753056e728d096bL179-R202)