### PR TITLE
Chore/UI additions

### DIFF
--- a/frontend/src/components/modals/GameInstructionsModal.tsx
+++ b/frontend/src/components/modals/GameInstructionsModal.tsx
@@ -1,4 +1,4 @@
-import { Divider, Group, Modal, Stack, Text } from "@mantine/core";
+import { Button, Divider, Group, Modal, Stack, Text } from "@mantine/core";
 import { useColorPalette } from "../../hooks/useColorPalette";
 import { IconCheck, IconX, IconCopy } from "@tabler/icons-react";
 import SanaboksiGameRow from "../game/SanaboksiGameRow";
@@ -39,6 +39,7 @@ export function GameInstructionsModal({
       onClose={onClose}
       size="lg"
       title={t("GameInstructionModal.HowToPlaySanaboksi")}
+      withCloseButton={false}
       styles={{
         header: { backgroundColor: colorPalette[0], color: colorPalette[1] },
         body: {
@@ -177,6 +178,24 @@ export function GameInstructionsModal({
       <Text styles={{ root: { marginTop: textMarginTop + 5 } }}>
         {t("GameInstructionModal.HaveFunWithSanaboksi")}
       </Text>
+      <Group style={{ width: "100%", justifyContent: "flex-end" }}>
+        <Button
+          onClick={onClose}
+          color={colorPalette[0]}
+          styles={{
+            label: {
+              color: colorPalette[1],
+            },
+            root: {
+              backgroundColor: colorPalette[0],
+              borderColor: colorPalette[1],
+              borderWidth: 3,
+            },
+          }}
+        >
+          {t("Actions.Close")}
+        </Button>
+      </Group>
     </Modal>
   );
 }


### PR DESCRIPTION
This pull request updates the `GameInstructionsModal` component to improve its usability and appearance. The main change is the addition of a custom close button styled to match the application's color palette, and the removal of the default close button in the modal header.

**Modal close UX improvements:**

* Added a custom-styled `Button` labeled with the localized "Close" text at the bottom right of the modal, which triggers the `onClose` handler.
* Disabled the default close button in the modal header by setting `withCloseButton={false}`.

**Dependency update:**

* Imported `Button` from `@mantine/core` to support the new custom close button.