### PR TITLE
Chore/Fix Dockerfiles and entrypoint files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,10 +17,8 @@ RUN ./gradlew --no-daemon bootJar
 
 # Java JRE base image for run
 FROM eclipse-temurin:25-jre AS run
-# Install curl for healthcheck
-RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
-# Install SQLite for database
-RUN apt update && apt install -y sqlite3 && rm -rf /var/lib/apt/lists/*
+# Install curl for healthcheck and SQLite for database
+RUN apt update && apt install -y curl sqlite3 && rm -rf /var/lib/apt/lists/*
 # Working directory inside the image
 WORKDIR /workdir
 # Copy built .jar file from build stage
@@ -30,5 +28,5 @@ EXPOSE 8080
 # Copy database files and entrypoint script
 COPY --from=build /workdir/src/main/resources/databaseInit ./databaseInit
 COPY entrypoint.sh .
-RUN sed -i 's/\r$//' ./entrypoint.sh && chmod +x ./entrypoint.sh
+RUN sed -i 's/\r$//' ./entrypoint.sh ./databaseInit/reseed_database.sh && chmod +x ./entrypoint.sh ./databaseInit/reseed_database.sh
 CMD ["./entrypoint.sh"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN ./gradlew --no-daemon bootJar
 # Java JRE base image for run
 FROM eclipse-temurin:25-jre AS run
 # Install curl for healthcheck and SQLite for database
-RUN apt update && apt install -y curl sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y --no-install-recommends curl sqlite3 && rm -rf /var/lib/apt/lists/*
 # Working directory inside the image
 WORKDIR /workdir
 # Copy built .jar file from build stage

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,9 +1,7 @@
 # Java JDK base image for build
 FROM eclipse-temurin:25-jdk
-# Install curl for healthcheck
-RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
-# Install SQLite for database
-RUN apt update && apt install -y sqlite3 && rm -rf /var/lib/apt/lists/*
+# Install curl for healthcheck and SQLite for database
+RUN apt update && apt install -y curl sqlite3 && rm -rf /var/lib/apt/lists/*
 # Working directory inside the image
 WORKDIR /workdir
 # Copy Gradle wrapper and build configuration first for better caching
@@ -20,5 +18,5 @@ EXPOSE 8080
 # Copy database files and entrypoint script
 COPY src/main/resources/databaseInit ./databaseInit
 COPY entrypoint.dev.sh .
-RUN chmod +x ./entrypoint.dev.sh
+RUN sed -i 's/\r$//' ./entrypoint.dev.sh ./databaseInit/reseed_database.sh && chmod +x ./entrypoint.dev.sh ./databaseInit/reseed_database.sh
 CMD ["./entrypoint.dev.sh"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Java JDK base image for build
 FROM eclipse-temurin:25-jdk
 # Install curl for healthcheck and SQLite for database
-RUN apt update && apt install -y curl sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y --no-install-recommends curl sqlite3 && rm -rf /var/lib/apt/lists/*
 # Working directory inside the image
 WORKDIR /workdir
 # Copy Gradle wrapper and build configuration first for better caching

--- a/backend/entrypoint.dev.sh
+++ b/backend/entrypoint.dev.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
+set -e
 
 if [ ! -f /database/database.db ]; then
   if [ -f /workdir/databaseInit/reseed_database.sh ]; then
     chmod +x /workdir/databaseInit/reseed_database.sh
-    cd /workdir/databaseInit
-    ./reseed_database.sh
-    cd /workdir
+    /workdir/databaseInit/reseed_database.sh
   else
     echo "Error: reseed_database.sh not found in /workdir/databaseInit, cannot initialize database."
     exit 1
   fi
 fi
 
-./gradlew classes --continuous --no-daemon & ./gradlew bootRun --no-daemon --args='--spring.profiles.active=dev'
+./gradlew classes --continuous --no-daemon & ./gradlew bootRun --continuous --no-daemon --args='--spring.profiles.active=dev'

--- a/backend/entrypoint.dev.sh
+++ b/backend/entrypoint.dev.sh
@@ -11,4 +11,4 @@ if [ ! -f /database/database.db ]; then
   fi
 fi
 
-./gradlew classes --continuous --no-daemon & ./gradlew bootRun --continuous --no-daemon --args='--spring.profiles.active=dev'
+./gradlew classes --continuous --no-daemon & ./gradlew bootRun --no-daemon --args='--spring.profiles.active=dev'

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
+set -e
 
 if [ ! -f /database/database.db ]; then
   if [ -f /workdir/databaseInit/reseed_database.sh ]; then
     chmod +x /workdir/databaseInit/reseed_database.sh
-    cd /workdir/databaseInit
-    ./reseed_database.sh
-    cd /workdir
+    /workdir/databaseInit/reseed_database.sh
   else
     echo "Error: reseed_database.sh not found in /workdir/databaseInit, cannot initialize database."
     exit 1


### PR DESCRIPTION
This pull request refactors the Docker setup and entrypoint scripts for both production and development environments to streamline dependency installation and script execution. The main improvements include consolidating package installations, ensuring proper handling of line endings and permissions for shell scripts, and simplifying the logic for running database reseeding scripts.

**Dockerfile improvements:**

* Combined the installation of `curl` and `sqlite3` into a single `apt install` command in both `backend/Dockerfile` and `backend/Dockerfile.dev` to simplify and speed up image builds. [[1]](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L20-R21) [[2]](diffhunk://#diff-fc0781121c673bc4c7088af7eac47a57f25d9dd6c40e983cf4bb320d660d2967L3-R4)
* Updated the `RUN` commands to normalize line endings and set execute permissions for both entrypoint scripts and the `reseed_database.sh` script, ensuring they can be executed regardless of the host OS. [[1]](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L33-R31) [[2]](diffhunk://#diff-fc0781121c673bc4c7088af7eac47a57f25d9dd6c40e983cf4bb320d660d2967L23-R21)

**Entrypoint script enhancements:**

* Added `set -e` to both `entrypoint.sh` and `entrypoint.dev.sh` to ensure the scripts exit immediately on errors, improving reliability. [[1]](diffhunk://#diff-7f1141f9bd8e768a3fc95dc5e97726ca7895df9b026f06e92c805ab1b65d2ec0R2-R7) [[2]](diffhunk://#diff-204410ec3434481722ef9aab5382167fdb5fe038b15198e63d1cf462f99cf478R2-R14)
* Simplified the logic for running the `reseed_database.sh` script by removing unnecessary directory changes and executing the script directly, reducing potential errors and making the scripts easier to maintain. [[1]](diffhunk://#diff-7f1141f9bd8e768a3fc95dc5e97726ca7895df9b026f06e92c805ab1b65d2ec0R2-R7) [[2]](diffhunk://#diff-204410ec3434481722ef9aab5382167fdb5fe038b15198e63d1cf462f99cf478R2-R14)