### PR TITLE
Chore/Rename workflows

### DIFF
--- a/.github/workflows/cd-deploy-to-azure.yaml
+++ b/.github/workflows/cd-deploy-to-azure.yaml
@@ -27,6 +27,7 @@ jobs:
   build-and-deploy-backend-container-to-azure:
     name: Build and deploy backend container to Azure
     runs-on: ubuntu-latest
+    # Needs job to make sure the correct tag is used for images
     needs: get-version-number-from-latest-tag
     env:
       VERSION_NUMBER: ${{ needs.get-version-number-from-latest-tag.outputs.version_number }}
@@ -43,7 +44,7 @@ jobs:
     - name: Build and deploy backend container
       uses: azure/container-apps-deploy-action@v2
       with:
-        acrUsername: ${{ secrets.AZURE_CONTAINER_REGISTRY_USERNAME}}
+        acrUsername: ${{ secrets.AZURE_CONTAINER_REGISTRY_USERNAME }}
         acrPassword: ${{ secrets.AZURE_CONTAINER_REGISTRY_PASSWORD }}
         dockerfilePath: Dockerfile
         appSourcePath: ${{ github.workspace }}/backend

--- a/.github/workflows/cd-update-version.yaml
+++ b/.github/workflows/cd-update-version.yaml
@@ -40,8 +40,8 @@ jobs:
               
               core.setOutput('update_label', updateLabel);
 
-      - name: Create new version number
-        id: version_number
+      - name: Create a new version number
+        id: create-new-version-number
         uses: actions/github-script@v8
         env:
           UPDATE_LABEL: ${{ steps.update_label.outputs.update_label }}
@@ -74,7 +74,7 @@ jobs:
       - name: Check semantic versioning
         uses: actions/github-script@v8
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
         with:
           script: |
             const versionNumber = process.env.VERSION_NUMBER;
@@ -86,20 +86,20 @@ jobs:
 
       - name: Open a new branch
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
         run: |
           git switch -c update/update-version-to-${VERSION_NUMBER}
 
       - name: Update backend version
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
         run: |
           cd backend
           sed -i "s/version = '.*'/version = '${VERSION_NUMBER}'/" build.gradle
 
       - name: Update frontend version
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
         run: |
           cd frontend
           npm version "${VERSION_NUMBER}" --no-git-tag-version
@@ -107,7 +107,7 @@ jobs:
       - name: Run Git operations
         id: git-operations
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
           UPDATE_LABEL: ${{ steps.update_label.outputs.update_label }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -140,14 +140,22 @@ jobs:
           # Merge PR and close branch
           gh pr merge update/update-version-to-${VERSION_NUMBER} --merge --delete-branch --auto
 
-      - name: Create new tag
+      - name: Create a new tag
+        id: create-new-tag
         if: ${{ steps.git-operations.outcome == 'success' }}
         env:
-          VERSION_NUMBER: ${{ steps.version_number.outputs.version_number }}
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           git switch main
           git pull origin main
           git tag v${VERSION_NUMBER}
           git push origin v${VERSION_NUMBER}
+
+      - name: Trigger deployment workflow
+        if: ${{ steps.create-new-tag.outcome == 'success' }}
+        env:
+          VERSION_NUMBER: ${{ steps.create-new-version-number.outputs.version_number }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
           gh workflow run cd-deploy-to-azure.yaml --ref v${VERSION_NUMBER}

--- a/.github/workflows/ci-run-backend-and-frontend-checks.yaml
+++ b/.github/workflows/ci-run-backend-and-frontend-checks.yaml
@@ -9,6 +9,7 @@ jobs:
   run-backend-formatting-check:
     name: BE formatting check
     runs-on: ubuntu-latest
+    # Run checks only on feature PRs, not on PRs that update version
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'update/update-version-to-') }}
 
     steps:

--- a/.github/workflows/ci-run-update-version-label-check.yaml
+++ b/.github/workflows/ci-run-update-version-label-check.yaml
@@ -1,4 +1,4 @@
-name: CD / Run update version label check
+name: CI / Run update version label check
 description: Checks that feature PRs have an update version label
 
 on:

--- a/.github/workflows/ci-run-update-version-label-check.yaml
+++ b/.github/workflows/ci-run-update-version-label-check.yaml
@@ -4,6 +4,7 @@ description: Checks that feature PRs have an update version label
 on:
   pull_request:
     types: [synchronize, reopened, labeled, unlabeled]
+# Concurrency ensures workflow runs only once, even if a PR with two labels would trigger the workflow twice
 concurrency:
   group: version-label-check-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve versioning and deployment automation, as well as to clarify workflow intent and prevent unnecessary runs. The most significant changes are focused on standardizing environment variable usage, improving workflow job naming for clarity, and ensuring workflows only run when appropriate.

**Workflow improvements and automation:**

* Standardized the naming and usage of the version number output in `.github/workflows/cd-update-version.yaml` by renaming the step from `version_number` to `create-new-version-number` and updating all subsequent references. This improves clarity and reduces the risk of referencing the wrong output. [[1]](diffhunk://#diff-024878964fa290c1531b75c5ec305aa0bc3479de7439f18f07157339c3fc7f6fL43-R44) [[2]](diffhunk://#diff-024878964fa290c1531b75c5ec305aa0bc3479de7439f18f07157339c3fc7f6fL77-R77) [[3]](diffhunk://#diff-024878964fa290c1531b75c5ec305aa0bc3479de7439f18f07157339c3fc7f6fL89-R110)
* Added a new step to trigger the deployment workflow only after a new tag is successfully created in `.github/workflows/cd-update-version.yaml`, ensuring deployments are only triggered on valid version tags.
* Added comments and updated job dependencies in `.github/workflows/cd-deploy-to-azure.yaml` to clarify that the deployment job depends on the version number extraction job.

**Workflow control and clarity:**

* Added a condition to the backend formatting check job in `.github/workflows/ci-run-backend-and-frontend-checks.yaml` so it only runs on feature PRs and not on automated version update PRs.
* Renamed the update version label check workflow from "CD" to "CI" and added concurrency control to prevent duplicate runs if a PR is labeled/unlabeled simultaneously in `.github/workflows/ci-run-update-version-label-check.yaml`.