### PR TITLE
Chore/Update workflows

### DIFF
--- a/.github/workflows/ci-run-backend-and-frontend-checks.yaml
+++ b/.github/workflows/ci-run-backend-and-frontend-checks.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up backend workflow environment
         uses: ./.github/actions/setup-backend-workflow-environment
 
-      - name: Run BE formatting check 
+      - name: Run backend formatting check 
         run: cd backend && ./gradlew spotlessCheck
 
   run-frontend-formatting-check:
@@ -31,7 +31,7 @@ jobs:
       - name: Set up frontend workflow environment
         uses: ./.github/actions/setup-frontend-workflow-environment
 
-      - name: Run FE formatting check
+      - name: Run frontend formatting check
         run: cd frontend && npx prettier . --check
 
   run-frontend-linting-check:
@@ -45,7 +45,7 @@ jobs:
       - name: Set up frontend workflow environment
         uses: ./.github/actions/setup-frontend-workflow-environment
 
-      - name: Run FE linting check
+      - name: Run frontend linting check
         run: cd frontend && npx eslint .
 
   run-backend-unit-tests:
@@ -69,7 +69,7 @@ jobs:
           path: sanaboksi-backend-test.tar
           retention-days: 1
 
-      - name: Run BE unit tests in container
+      - name: Run backend unit tests in a container
         run: |
           mkdir -p "${{ github.workspace }}/backend/build/reports/tests"
           docker run --rm --name be-unit-tests \
@@ -100,14 +100,11 @@ jobs:
       - name: Load backend test image
         run: docker load -i sanaboksi-backend-test.tar
 
-      - name: Run BE integration tests in container
-        env:
-          CORS_ALLOWED_ORIGIN: http://localhost:5173
-          SQLITE_DB_PATH: /database/database.db
+      - name: Run backend integration tests in a container
         run: |
           mkdir -p "${{ github.workspace }}/backend/build/reports/tests"
           docker run --rm --name be-integration-tests \
-            -e CORS_ALLOWED_ORIGIN="${CORS_ALLOWED_ORIGIN}" -e SQLITE_DB_PATH="${SQLITE_DB_PATH}" \
+            -e SQLITE_DB_PATH="/database/database.db" \
             -v "${{ github.workspace }}/backend/build/reports/tests:/workdir/build/reports/tests" \
             sanaboksi-backend-test \
             sh -c "./databaseInit/reseed_database.sh && ./gradlew --no-daemon integrationTest"
@@ -147,9 +144,6 @@ jobs:
       - name: Show frontend logs on container build failure
         if: ${{ failure() }}
         run: docker logs sanaboksi_frontend
-
-      - name: Wait for frontend to be ready
-        run: until curl --output /dev/null --silent --head --fail http://localhost:5173; do sleep 5; done
 
       - name: Run end-to-end tests
         run: cd frontend && npx playwright test


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow file `.github/workflows/ci-run-backend-and-frontend-checks.yaml` to improve the clarity and consistency of job and step names, as well as to make minor adjustments to environment variable usage in test steps. The changes are primarily focused on making the workflow steps easier to understand and maintain.

**Workflow step naming improvements:**

* Standardized step names by replacing abbreviations like "BE" and "FE" with "backend" and "frontend" for formatting and linting checks. [[1]](diffhunk://#diff-00772f9aec8a0b1076490f472d3373e0d109ab46c89d13f4b2ed68ee324fa2ecL20-R20) [[2]](diffhunk://#diff-00772f9aec8a0b1076490f472d3373e0d109ab46c89d13f4b2ed68ee324fa2ecL34-R34) [[3]](diffhunk://#diff-00772f9aec8a0b1076490f472d3373e0d109ab46c89d13f4b2ed68ee324fa2ecL48-R48)
* Updated test step names to be more descriptive, such as "Run backend unit tests in a container" and "Run backend integration tests in a container." [[1]](diffhunk://#diff-00772f9aec8a0b1076490f472d3373e0d109ab46c89d13f4b2ed68ee324fa2ecL72-R72) [[2]](diffhunk://#diff-00772f9aec8a0b1076490f472d3373e0d109ab46c89d13f4b2ed68ee324fa2ecL103-R107)

**Test configuration adjustments:**

* Removed the `CORS_ALLOWED_ORIGIN` environment variable from the backend integration test step, leaving only `SQLITE_DB_PATH` set explicitly.
* Removed the explicit "Wait for frontend to be ready" step before running end-to-end tests, likely streamlining the workflow.