### PR TITLE
Issue/#160 Changing difficulty should not automatically trigger game grid reload

### DIFF
--- a/frontend/src/components/modals/GameSettingsModal.tsx
+++ b/frontend/src/components/modals/GameSettingsModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { colors, gameConstants } from "../../utils/Constants";
 import { Group, Space, Text } from "@mantine/core";
@@ -21,6 +22,7 @@ export function GameSettingsModal({ opened, onClose }: GameSettingsModalProps) {
   const {
     gameDifficulty: { wordLength, setWordLength },
   } = useGameSettingsContext();
+  const [tempWordLength, setTempWordLength] = useState<number>(wordLength);
 
   const handleDifficultyChange = (value: string) => {
     const numValue = Number(value);
@@ -33,32 +35,31 @@ export function GameSettingsModal({ opened, onClose }: GameSettingsModalProps) {
         gameConstants.WORD_LENGTH_7,
       ].includes(numValue)
     ) {
-      setWordLength(numValue);
+      setTempWordLength(numValue);
     }
+  };
+
+  const handleSave = () => {
+    setWordLength(tempWordLength);
+    onClose();
+  };
+
+  const handleClose = () => {
+    setTempWordLength(wordLength);
+    onClose();
   };
 
   return (
     <StyledModal
       opened={opened}
-      onClose={onClose}
+      onClose={handleClose}
       title={t("GameSettingsModal.Settings")}
     >
-      <Space h="0.75rem" />
-
-      <StyledIconTextRow
-        ariaLabel={t("AriaLabe.AlertIcon")}
-        icon={IconAlertCircle}
-        color={colorPalette[colors.SECONDARY_COLOR_1]}
-        text={t(
-          "GameSettingsModal.IfYouChangeDifficultyYouWillLoseYourProgress",
-        )}
-      />
-
       <StyledText text={t("GameSettingsModal.ChooseDifficulty")} />
 
       <StyledSegmentedControl
         ariaLabel={t("GameSettingsModal.ChooseDifficulty")}
-        value={String(wordLength)}
+        value={String(tempWordLength)}
         onChange={handleDifficultyChange}
         data={[
           {
@@ -81,10 +82,26 @@ export function GameSettingsModal({ opened, onClose }: GameSettingsModalProps) {
         orientation="vertical"
       />
 
+      <Space h="xl" />
+
+      <StyledIconTextRow
+        ariaLabel={t("AriaLabe.AlertIcon")}
+        icon={IconAlertCircle}
+        color={colorPalette[colors.SECONDARY_COLOR_1]}
+        text={t(
+          "GameSettingsModal.SavingLoadsANewGameGridAndYouLoseYourProgessInThisGameGrid",
+        )}
+      />
+
       <Group justify="flex-end">
         <StyledButton
+          ariaLabel={t("Actions.Save")}
+          onClick={handleSave}
+          buttonText={t("Actions.Save")}
+        />
+        <StyledButton
           ariaLabel={t("Actions.BackToGame")}
-          onClick={onClose}
+          onClick={handleClose}
           buttonText={t("Actions.BackToGame")}
         />
       </Group>

--- a/frontend/src/localization/locales/fi/fiTranslations.json
+++ b/frontend/src/localization/locales/fi/fiTranslations.json
@@ -3,7 +3,8 @@
     "Close": "Sulje",
     "BackToGame": "Takaisin peliin",
     "LoadNewGame": "Lataa uusi peli",
-    "Confirm": "Vahvista"
+    "Confirm": "Vahvista",
+    "Save": "Tallenna"
   },
   "GameGridButton": {
     "NewGame": "Uusi peli",
@@ -64,7 +65,7 @@
     "FiveLetters": "5 kirjainta",
     "SixLetters": "6 kirjainta",
     "SevenLetters": "7 kirjainta",
-    "IfYouChangeDifficultyYouWillLoseYourProgress": "Jos muutat vaikeustasoa, menetät mahdollisen edistymisesi tässä ruudukossa!"
+    "SavingLoadsANewGameGridAndYouLoseYourProgessInThisGameGrid": "Tallentaminen lataa uuden peliruudun, ja menetät edistymisesi tässä peliruudussa."
   },
   "GameInfoModal": {
     "WhatSanaboksi": "Mikä Sanaboksi?",

--- a/frontend/tests/game-settings-tests.spec.ts
+++ b/frontend/tests/game-settings-tests.spec.ts
@@ -16,9 +16,10 @@ async function getGridLetters(page: Page) {
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
+  await page.waitForTimeout(1_000);
 });
 
-test("Changing game difficulty to four letters loads a correct new game grid", async ({
+test("Changing game difficulty to four letters and saving loads a correct new game grid", async ({
   page,
 }) => {
   await page.getByRole("button", { name: "Avaa pelin asetukset" }).click();
@@ -27,7 +28,7 @@ test("Changing game difficulty to four letters loads a correct new game grid", a
 
   await page.getByText("4 kirjainta").click();
 
-  await page.getByRole("button", { name: "Sulje" }).click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
 
   await page.waitForTimeout(1_000);
 
@@ -39,7 +40,7 @@ test("Changing game difficulty to four letters loads a correct new game grid", a
   });
 });
 
-test("Changing game difficulty to six letters loads a correct new game grid", async ({
+test("Changing game difficulty to six letters and saving loads a correct new game grid", async ({
   page,
 }) => {
   await page.getByRole("button", { name: "Avaa pelin asetukset" }).click();
@@ -48,7 +49,7 @@ test("Changing game difficulty to six letters loads a correct new game grid", as
 
   await page.getByText("6 kirjainta").click();
 
-  await page.getByRole("button", { name: "Sulje" }).click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
 
   await page.waitForTimeout(1_000);
 
@@ -60,7 +61,7 @@ test("Changing game difficulty to six letters loads a correct new game grid", as
   });
 });
 
-test("Changing game difficulty to seven letters loads a correct new game grid", async ({
+test("Changing game difficulty to seven letters and saving loads a correct new game grid", async ({
   page,
 }) => {
   await page.getByRole("button", { name: "Avaa pelin asetukset" }).click();
@@ -69,7 +70,7 @@ test("Changing game difficulty to seven letters loads a correct new game grid", 
 
   await page.getByText("7 kirjainta").click();
 
-  await page.getByRole("button", { name: "Sulje" }).click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
 
   await page.waitForTimeout(1_000);
 
@@ -79,4 +80,24 @@ test("Changing game difficulty to seven letters loads a correct new game grid", 
     expect(row.filter((l) => l === "").length).toBe(6);
     expect(row.filter((l) => l !== "").length).toBe(1);
   });
+});
+
+test("Changing game difficulty and leaving the modal does not load a new game grid", async ({
+  page,
+}) => {
+  const initialGrid = await getGridLetters(page);
+
+  await page.getByRole("button", { name: "Avaa pelin asetukset" }).click();
+
+  await expect(page.getByRole("heading", { name: "Asetukset" })).toBeVisible();
+
+  await page.getByText("7 kirjainta").click();
+
+  await page.getByRole("button", { name: "Takaisin peliin" }).click();
+
+  await page.waitForTimeout(1_000);
+
+  const comparedGrid = await getGridLetters(page);
+
+  expect(initialGrid).toEqual(comparedGrid);
 });


### PR DESCRIPTION
Closes #160 

Update game settings so that selecting new game difficulty does not automatically reload a new game grid. The new grid loads only if user clicks the save button.

Update also translations and e2e tests.