### PR TITLE
Issue/#190 Settings change warning is always shown

### DIFF
--- a/frontend/src/components/modals/GameSettingsModal.tsx
+++ b/frontend/src/components/modals/GameSettingsModal.tsx
@@ -84,14 +84,16 @@ export function GameSettingsModal({ opened, onClose }: GameSettingsModalProps) {
 
       <Space h="xl" />
 
-      <StyledIconTextRow
-        ariaLabel={t("AriaLabe.AlertIcon")}
-        icon={IconAlertCircle}
-        color={colorPalette[colors.SECONDARY_COLOR_1]}
-        text={t(
-          "GameSettingsModal.SavingLoadsANewGameGridAndYouLoseYourProgessInThisGameGrid",
-        )}
-      />
+      {wordLength != tempWordLength && (
+        <StyledIconTextRow
+          ariaLabel={t("AriaLabel.AlertIcon")}
+          icon={IconAlertCircle}
+          color={colorPalette[colors.SECONDARY_COLOR_1]}
+          text={t(
+            "GameSettingsModal.SavingLoadsANewGameGridAndYouLoseYourProgessInThisGameGrid",
+          )}
+        />
+      )}
 
       <Group justify="flex-end">
         <StyledButton

--- a/frontend/tests/game-settings-tests.spec.ts
+++ b/frontend/tests/game-settings-tests.spec.ts
@@ -101,3 +101,19 @@ test("Changing game difficulty and leaving the modal does not load a new game gr
 
   expect(initialGrid).toEqual(comparedGrid);
 });
+
+test("Changing game difficulty renders the reload warning", async ({
+  page,
+}) => {
+  const warningText =
+    "Tallentaminen lataa uuden peliruudun, ja menetät edistymisesi tässä peliruudussa.";
+
+  await page.getByRole("button", { name: "Avaa pelin asetukset" }).click();
+
+  await expect(page.getByRole("heading", { name: "Asetukset" })).toBeVisible();
+  await expect(page.getByText(warningText)).not.toBeVisible();
+
+  await page.getByText("7 kirjainta").click();
+
+  await expect(page.getByText(warningText)).toBeVisible();
+});


### PR DESCRIPTION
Add conditional render to show settings warning only when difficulty is change.

Update Playwright tests.